### PR TITLE
Add active border to link of section user is in

### DIFF
--- a/input/assets/css/override.less
+++ b/input/assets/css/override.less
@@ -129,6 +129,10 @@ a:hover {
     background: none;
 }
 
+.main-header .navbar .nav > li.active {
+  border-bottom: 1px solid #0479A3;
+}
+
 // navigation button (mobile)
 .navbar-toggle {
   color: #0479A3;


### PR DESCRIPTION
![addedaffordance](https://user-images.githubusercontent.com/5075285/29245658-643eb986-7faf-11e7-9397-92aa7f6fa29e.PNG)

- Signals to the user which section of the site they are currently in.
- Fixes #16
- (note this change is unrelated to the points I made on the issue)