### PR TITLE
Add section about snippets to docs

### DIFF
--- a/input/docs/handbook/snippets/index.md
+++ b/input/docs/handbook/snippets/index.md
@@ -1,0 +1,7 @@
+# Snippets
+
+Snippets are short code templates that can be inserted into your code. They are used to reduce the amount of typing when writing repetetive code. The snippets are activated by writing the shortcut of the snippet and hitting **Tab** (**Tab, Tab** in Visual Studio).
+
+The **snippets** folder in the [ReactiveUI repository](https://github.com/reactiveui/reactiveui/) on Github contains snippets for inserting common code when using ReactiveUI. There are snippets available for Visual Studio, Visual Studio for Mac, Visual Studio Code, JetBrains Resharper and JetBrains Rider.
+
+All the ReactiveUI snippet shortcuts start with the letters **rui** making them easy to find when using auto complete in your editor of choice.


### PR DESCRIPTION
A section explaining the snippets added in [#1444 in the ReactiveUI repo](https://github.com/reactiveui/ReactiveUI/pull/1444)