### PR TITLE
Add notice about disposing command-to-event bindings

### DIFF
--- a/input/docs/handbook/commands/binding-commands.md
+++ b/input/docs/handbook/commands/binding-commands.md
@@ -39,6 +39,8 @@ this.BindCommand(
 
 Here, the `SomeEvent` on `myControl` will be used to trigger command execution instead of the default event.
 
+> **Note** When using this overload inside `WhenActivated`, it's important to dispose the binding when deactivating the view. `BindCommand` will subscribe to the given event each time the view is activated, if the binding is not disposed it will not unsubscribe from the event. This will lead to multiple subscriptions to the event, which will make the command execute once for each of the event subscriptions.
+
 Finally, `BindCommand` also provides overloads that allow you to specify a parameter with which to execute the command. The parameter can be provided as a function, an observable, or even an expression that resolves a property on the view model:
 
 ```cs


### PR DESCRIPTION
This is to prevent multiple event subscriptions when using the overload of `BindCommand` with the `toEvent` parameter and passing an event name.

This is related to [PR #1484 in the ReactveUI repo](https://github.com/reactiveui/ReactiveUI/pull/1484)