### PR TITLE
Fixed wrong meaning of WPF

### DIFF
--- a/input/docs/getting-started/installation/nuget-packages/index.md
+++ b/input/docs/getting-started/installation/nuget-packages/index.md
@@ -23,7 +23,7 @@ MyCoolApps.UnitTests (tests)
 * Install `reactiveui-events-winforms` into your application.
 * Install `reactiveui-testing` into your tests.
 
-# Windows Presentation Framework
+# Windows Presentation Foundation
 
 _IMPORTANT_: The information below is forward looking that is relevant once ReactiveUI v8 ships. Until it does just use the drop `-wpf` off from all packages.
 

--- a/input/docs/getting-started/installation/setting-up-a-new-project.md
+++ b/input/docs/getting-started/installation/setting-up-a-new-project.md
@@ -20,7 +20,7 @@ MyCoolApps.UnitTests (tests)
 * Install `reactiveui-events-winforms` into your portable class library and application.
 * Install `reactiveui-testing` into your tests.
 
-# Windows Presentation Framework
+# Windows Presentation Foundation
 
 _IMPORTANT_: The information below is forward looking that is relevant once ReactiveUI v8 ships. Until it does just use the drop `-wpf` off from all packages.
 

--- a/input/docs/handbook/data-binding/windows-presentation-foundation.md
+++ b/input/docs/handbook/data-binding/windows-presentation-foundation.md
@@ -1,4 +1,4 @@
-# Windows Presentation Framework
+# Windows Presentation Foundation
 
 Super important to use the `WhenActivated` method on WPF to avoid leaking memory  -> https://codereview.stackexchange.com/questions/74642/a-viewmodel-using-reactiveui-6-that-loads-and-sends-data
 


### PR DESCRIPTION
Fixed references to WPF as "Windows Presentation **Framework**" instead of "Windows Presentation **Foundation**".