### PR TITLE
Fix incorrect StackOverflow url in footer

### DIFF
--- a/input/_Footer.cshtml
+++ b/input/_Footer.cshtml
@@ -11,7 +11,7 @@
                <a href="/support" target="_blank">Support</a>
            </li>
            <li class="list-inline-item">
-               <a href="/stack-overflow" target="_blank">StackOverflow</a>
+               <a href="/stackoverflow" target="_blank">StackOverflow</a>
            </li>
            <li class="list-inline-item">
                <a href="/branding" target="_blank">Branding</a>


### PR DESCRIPTION
Redirecting to `stack-overflow` instead of `stackoverflow` as defined in /input/_redirects