### PR TITLE
Remove unused sponsorship files

### DIFF
--- a/input/sponsorship/index.cshtml
+++ b/input/sponsorship/index.cshtml
@@ -1,1 +1,0 @@
-<meta http-equiv="refresh" content="1;url=mailto:hello@reactiveui.net?%3Fsubject%3D%22Howdy%2C%20can%20you%20send%20me%20information%20about%20sponsoring%20the%20project%3F%22" />

--- a/input/sponsorship/index.md
+++ b/input/sponsorship/index.md
@@ -1,2 +1,0 @@
-<blockquote class="twitter-tweet" data-lang="en"><p lang="en" dir="ltr">I wonder how many(me included) who see these sponsors as &quot;Oh, they like <a href="https://twitter.com/hashtag/webpack?src=hash">#webpack</a>! That must be a nice place to work at as a dev! 😍&quot; <a href="https://t.co/RvcxfcKUAd">https://t.co/RvcxfcKUAd</a></p>&mdash; 🌍 🌳 🐝 🌊 🏳️‍🌈 (@reimertz) <a href="https://twitter.com/reimertz/status/912397014738104320">September 25, 2017</a></blockquote>
-<script async src="//platform.twitter.com/widgets.js" charset="utf-8"></script>


### PR DESCRIPTION
These aren't used because of the redirect from /sponsorship to /support and are creating a build warning because the two files end up at the same place.