### PR TITLE
Fix Xamarin.Forms sample link

### DIFF
--- a/input/docs/samples/index.md
+++ b/input/docs/samples/index.md
@@ -34,7 +34,7 @@ Send in a pull-request linking to the source code of something you have built.
 
 # Xamarin Forms
 
-* https://github.com/GiusepeCasagrande/Cinephile
+* https://github.com/reactiveui/ReactiveUI/tree/develop/samples/xamarin-forms
 * https://github.com/GiusepeCasagrande/RoutingSimpleSample
 
 # Xamarin Mac


### PR DESCRIPTION
The original link redirects to the updated URL here.