### PR TITLE
Fix license link

### DIFF
--- a/input/index.cshtml
+++ b/input/index.cshtml
@@ -125,7 +125,7 @@ ShowInNavbar: false
         <div class=" span6 col-md-6">
             <h3>Open-source</h3>
 
-            <p>ReactiveUI is developed under an <a href="License" target="_blank">OSI-approved open source license</a>, making it freely usable and distributable, even for commercial use. We ❤ the people who are involved in this project, and we’d love <a href="Contribute">to have you on board</a>, especially if you are just getting started or have never contributed to open-source before.</p>
+            <p>ReactiveUI is developed under an <a href="license" target="_blank">OSI-approved open source license</a>, making it freely usable and distributable, even for commercial use. We ❤ the people who are involved in this project, and we’d love <a href="Contribute">to have you on board</a>, especially if you are just getting started or have never contributed to open-source before.</p>
             
             <p>ReactiveUI is a <a href="http://dotnetfoundation.org/" target="_blank">.NET Foundation</a> project. Other projects that are associated with the foundation include the .NET Compiler Platform ("Roslyn") as well as the ASP.NET family of projects, .NET Core &amp; Xamarin Forms.</p>
         </div>


### PR DESCRIPTION
https://reactiveui.net/License page doesn't exist,
but https://reactiveui.net/license works.