### PR TITLE
Reduce empty space on main page

### DIFF
--- a/input/index.cshtml
+++ b/input/index.cshtml
@@ -10,28 +10,26 @@ ShowInNavbar: false
 <div class="header">
     <div class=" container">
         <div class=" row">
-            <div class=" span12 col-sm-12">
-                <div class="branding">
-                    <img class="img-responsive" src="@Context.GetLink("/assets/img/logo.png")" />
-                </div>
-            </div>
-        </div>
-        <div class=" row">
             <div class=" span12 col-sm-12 hidden-xs">
                 <br>
             </div>
-
             <div class=" span6 col-md-6">
                 <div class="branding">
-                    <h3>An advanced, composable, functional reactive model-view-viewmodel framework for all .NET platforms</h3>
-                    <h3 class="no-margin">
-                        <a class="" href="@Context.GetLink("/docs/getting-started")">
-                            Get Started!
-                        </a>
-                    </h3>
+                    <div class="row">
+                        <div class="col-md-4">
+                            <img class="img-responsive" src="@Context.GetLink("/assets/img/logo.png")" />
+                        </div>
+                        <div class="col-md-8">
+                            <h3>An advanced, composable, functional reactive model-view-viewmodel framework for all .NET platforms</h3>
+                            <h3 class="no-margin">
+                                <a class="" href="@Context.GetLink("/docs/getting-started")">
+                                    Get Started!
+                                </a>
+                            </h3>
+                        </div>
+                    </div>
                 </div>
             </div>
-
 
             <div class=" span6 col-md-6 hidden-sm hidden-xs">
                 <div class="branding sample">


### PR DESCRIPTION
Removed large space in front of the main page. It seemed rather odd to me that it was there, maybe without it the website would look more elegant!

Before:

![image](https://user-images.githubusercontent.com/6759207/39048940-f8bd861a-44a7-11e8-80b0-4911d34e88e9.png)

After:

![image](https://user-images.githubusercontent.com/6759207/39048953-0901de40-44a8-11e8-81b8-6ff05716d3c8.png)
