### PR TITLE
Bump Cake to v0.29.0

### DIFF
--- a/.vsts-ci.yml
+++ b/.vsts-ci.yml
@@ -4,7 +4,7 @@ trigger:
 queue: Hosted VS2017
 
 steps:
-- powershell: .\build.ps1
+- powershell: .\build.ps1 --settings_skipverification=true
   displayName: Build
   
 - task: PublishBuildArtifacts@1

--- a/build.cake
+++ b/build.cake
@@ -1,6 +1,6 @@
-#tool "nuget:https://api.nuget.org/v3/index.json?package=Wyam&version=1.0.0"
-#addin "nuget:https://api.nuget.org/v3/index.json?package=Cake.Git&version=0.16.0"
-#addin "nuget:https://api.nuget.org/v3/index.json?package=Cake.Wyam&version=1.0.0"
+#tool "nuget:https://api.nuget.org/v3/index.json?package=Wyam&version=1.2.0"
+#addin "nuget:https://api.nuget.org/v3/index.json?package=Cake.Git&version=0.18.0"
+#addin "nuget:https://api.nuget.org/v3/index.json?package=Cake.Wyam&version=1.2.0"
 #addin "nuget:https://api.nuget.org/v3/index.json?package=Octokit&version=0.27.0"
 
 using Octokit;

--- a/tools/packages.config
+++ b/tools/packages.config
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <packages>
-    <package id="Cake" version="0.21.1" />
+    <package id="Cake" version="0.29.0" />
 </packages>


### PR DESCRIPTION
Resolves #143 

- v0.21.1 doesn't allow for versioning of cake dependencies