### PR TITLE
Make Handbook page not blank

### DIFF
--- a/input/docs/handbook/index.cshtml
+++ b/input/docs/handbook/index.cshtml
@@ -1,4 +1,4 @@
 Order: 15
 ---
 
- This page is deliberately blank.
+@Html.Partial("_ChildPages")


### PR DESCRIPTION
When I was a newbie, I got confused when I opened the Handbook and it was blank. Let's display a list of contents instead of an empty page there.