### PR TITLE
Updating to Wyam 1.5.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,6 @@
 [Dd]ependencies/
 nuget.exe
 [Ll]ocal[Dd]eploy/
-config\.wyam\.dll
-
-config\.wyam\.hash
+/config.wyam.packages.xml
+/config.wyam.dll
+/config.wyam.hash

--- a/build.cake
+++ b/build.cake
@@ -1,6 +1,6 @@
-#tool "nuget:https://api.nuget.org/v3/index.json?package=Wyam&version=1.2.0"
+#tool "nuget:https://api.nuget.org/v3/index.json?package=Wyam&version=1.5.0"
 #addin "nuget:https://api.nuget.org/v3/index.json?package=Cake.Git&version=0.18.0"
-#addin "nuget:https://api.nuget.org/v3/index.json?package=Cake.Wyam&version=1.2.0"
+#addin "nuget:https://api.nuget.org/v3/index.json?package=Cake.Wyam&version=1.5.0"
 #addin "nuget:https://api.nuget.org/v3/index.json?package=Octokit&version=0.27.0"
 
 using Octokit;
@@ -91,8 +91,8 @@ Task("Preview")
 Task("Debug")
     .Does(() =>
     {
-        StartProcess("../Wyam/src/clients/Wyam/bin/Debug/wyam.exe",
-            "-a \"../Wyam/src/**/bin/Debug/*.dll\" -r \"docs -i\" -t \"../Wyam/themes/Docs/Samson\" -p --attach");
+        StartProcess("../Wyam/src/clients/Wyam/bin/Debug/net462/wyam.exe",
+            "-a \"../Wyam/tests/integration/Wyam.Examples.Tests/bin/Debug/net462/**/*.dll\" -r \"docs -i\" -t \"../Wyam/themes/Docs/Samson\" -p");
     });
 
 //////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
This PR updates the site to Wyam 1.5.0. I was expecting some trouble [based on this comment](https://github.com/reactiveui/website/issues/151#issuecomment-413901595) but the process was totally straightforward. It's possible that an intermediate version caused problems that 1.5.0 has now resolved.

Wyam did spit out some warnings about duplicate paths, but that doesn't look any different than the current site - there are a few open Wyam issues for API path resolution that might help with that in the future.