### PR TITLE
Make expander control look great

### DIFF
--- a/input/assets/css/override.less
+++ b/input/assets/css/override.less
@@ -180,3 +180,13 @@ iframe.embedded-video {
   width: 100%;
   height: 500px;
 }
+
+summary {
+  background: #02a1d8;
+  color: white;
+  font-weight: bold;
+  padding: 10px;
+  border-radius: 5px;
+  margin: 10px 0;
+  cursor: pointer;
+}


### PR DESCRIPTION
We can create en expander control in the .MD markup, but usually we don't use this feature, as expanders don't look great, see an example:

![](https://i.gyazo.com/50c98b8a22c2ca2e3d723703cb5bf6fa.gif)

Tried to improve this control so now it looks nice and we can use it.

![](https://i.gyazo.com/8b0a9efc6cc47aad7875db18e5c72c3a.gif)

This may help providing a great <a href="https://github.com/reactiveui/website/pull/171">getting started</a> guide.