### PR TITLE
Don't wrap long lines of code

### DIFF
--- a/input/assets/css/override.less
+++ b/input/assets/css/override.less
@@ -144,6 +144,7 @@ a:hover {
 .hljs {
   background: rgba(0, 0, 0, 0.024);
   padding: 8px !important;
+  white-space: pre;
 }
 
 .code-sample pre {


### PR DESCRIPTION
When I view the website via a mobile phone with a narrow screen, I can barely read the code:

![image](https://user-images.githubusercontent.com/6759207/44972419-bf3dff80-af61-11e8-8094-14b94b0cbedc.png)

This option is better (with horizontal scroll bar enabled in code snippets, so lines won't wrap):

![image](https://user-images.githubusercontent.com/6759207/44972457-e7c5f980-af61-11e8-80aa-74061326d9f0.png)
