### PR TITLE
Update syntax highlighting theme

### DIFF
--- a/input/assets/css/override.less
+++ b/input/assets/css/override.less
@@ -191,3 +191,69 @@ summary {
   margin: 10px 0;
   cursor: pointer;
 }
+
+// Use a fresh HLJS theme based on Atom's OneLight.
+pre {
+  border-color: #eee!mportant;
+}
+.hljs {
+  display: block;
+  overflow-x: auto;
+  padding: 0.5em;
+  color: #383a42;
+  background: #fafafa;
+}
+.hljs-comment,
+.hljs-quote {
+  color: #a0a1a7;
+}
+.hljs-doctag,
+.hljs-keyword,
+.hljs-formula,
+.hljs-section,
+.hljs-name,
+.hljs-selector-tag,
+.hljs-deletion,
+.hljs-subst {
+  color: #a626a4;
+}
+.hljs-literal {
+  color: #0184bb;
+}
+.hljs-string,
+.hljs-regexp,
+.hljs-addition,
+.hljs-attribute,
+.hljs-meta-string,
+.hljs-symbol,
+.hljs-bullet,
+.hljs-link,
+.hljs-meta,
+.hljs-selector-id,
+.hljs-title {
+  color: #4078f2;
+}
+.hljs-built_in,
+.hljs-class .hljs-title {
+  color: #c18401;
+}
+.hljs-attr,
+.hljs-variable,
+.hljs-template-variable,
+.hljs-type,
+.hljs-selector-class,
+.hljs-selector-attr,
+.hljs-selector-pseudo,
+.hljs-number {
+  color: #686a72;
+}
+.hljs-emphasis {
+  font-style: italic;
+}
+.hljs-strong {
+  font-weight: bold;
+}
+.hljs-link {
+  text-decoration: underline;
+}
+


### PR DESCRIPTION
ReactiveUI syntax highlighting theme used to be dark:
https://files.slack.com/files-pri/T02AG6QJM-FCKM4E4NM/image.png
Let's update it using colors from ReactiveUI and ReactiveExtensions logos:
https://files.slack.com/files-pri/T02AG6QJM-FCMJUPXLN/image.png
