### PR TITLE
Increase text line height

### DIFF
--- a/input/assets/css/override.less
+++ b/input/assets/css/override.less
@@ -35,6 +35,10 @@ a:hover {
   text-decoration: underline;
 }
 
+p {
+  line-height: 1.7
+}
+
 // documentation sidebar
 .sidebar-menu {
   li a:active {
@@ -255,4 +259,3 @@ pre {
 .hljs-link {
   text-decoration: underline;
 }
-


### PR DESCRIPTION
### Why?

> Many people with cognitive disabilities have trouble tracking lines of text when a block of text is single spaced. Providing spacing between 1.5 to 2 allows them to start a new line more easily once they have finished the previous one. 

See <a href="https://www.w3.org/TR/WCAG20-TECHS/C21.html">W3C C21: Specifying line spacing in CSS</a>

> Line spacing (leading) is at least space-and-a-half within paragraphs, and paragraph spacing is at least 1.5 times larger than the line spacing. 

See <a href="https://www.w3.org/TR/2008/REC-WCAG20-20081211/#visual-audio-contrast-visual-presentation">W3C Web Content Accessibility Guidelines (WCAG) 2.0</a>

### Before

<img src="https://user-images.githubusercontent.com/6759207/45118486-4c02dc00-b161-11e8-93d3-97df4e7463fe.png" width="500">

### After

<img src="https://user-images.githubusercontent.com/6759207/45118501-57ee9e00-b161-11e8-84e4-669b58b709d2.png" width="500">
