### PR TITLE
Mention DisposeWith on WhenActivated page

### DIFF
--- a/input/docs/handbook/when-activated/index.md
+++ b/input/docs/handbook/when-activated/index.md
@@ -75,8 +75,8 @@ public class ActivatableControl : ReactiveUserControl<ActivatableViewModel>
 
 As a rule of thumb for all platforms, you should use it for bindings and any time there's something your view sets up that will outlive the view bindings. It is also super useful for setting up things that should get added to the visual tree, even if they are not a disposable.
 
-# Do I need WhenActivated?
+# Do I need WhenActivated and DisposeWith?
 
-If you do a [WhenAny](../when-any) on anything other than `this`, you **need** to put it inside a `WhenActivated` block. If you just launch a window and then that window goes away when app goes away and you have nothing else to manage, you don't need `WhenActivated`. 
+If you do a [WhenAny](../when-any) on anything other than `this`, you **need** to put it inside a `WhenActivated` block and add a call to `DisposeWith`. If you just launch a window and then that window goes away when app goes away and you have nothing else to manage, you don't need `WhenActivated`. 
 
-Always use `WhenActivated` with XAML views, if you're writing `this.WhenAnyValue(x => x.ViewModel.Prop).BindTo(...)` or `this.Bind*(...)` (read more on bindings [here](../data-binding)). You should use it any time there's something your view sets up that will outlive the view - on a Xaml platform, you may have a subscription that you don't want to stay active when the view is detached from the visual tree. It's also useful for setting up things when you get added to the visual tree, although usually the correct place for something like that is in the ViewModel's `WhenActivated`. 
+Always use `WhenActivated` and `DisposeWith` with XAML views, if you're writing `this.WhenAnyValue(x => x.ViewModel.Prop).BindTo(...)` or `this.Bind*(...)` (read more on bindings [here](../data-binding)). You should use it any time there's something your view sets up that will outlive the view - on a Xaml platform, you may have a subscription that you don't want to stay active when the view is detached from the visual tree. It's also useful for setting up things when you get added to the visual tree, although usually the correct place for something like that is in the ViewModel's `WhenActivated`. 


### PR DESCRIPTION
We should mention `DisposeWith` when we are talking about memory leaks. I've seen a little misunderstanding in the <a href="https://reactivex.slack.com">Slack channel</a> so decided to clarify this :)