### PR TITLE
Fix Events typo

### DIFF
--- a/input/docs/getting-started/installation/xamarin-forms.md
+++ b/input/docs/getting-started/installation/xamarin-forms.md
@@ -20,5 +20,5 @@ Assuming the following project structure:
 
 * Install `ReactiveUI` into your netstandard libraries, platform library, applications and tests.
 * Install `ReactiveUI.XamForms` into your netstandard UI library, platform library, applications and tests.
-* Install `ReactiveUI.Event.XamForms` into your netstandard library and applications.
+* Install `ReactiveUI.Events.XamForms` into your netstandard library and applications.
 * Install `ReactiveUI.Testing` into your tests.


### PR DESCRIPTION
The package name is actually `ReactiveUI.Events.XamForms`, not `ReactiveUI.Event.XamForms`. https://reactiveui.net/docs/getting-started/installation/xamarin-forms