### PR TITLE
Improve code highlighter colors

### DIFF
--- a/input/assets/css/override.less
+++ b/input/assets/css/override.less
@@ -218,10 +218,10 @@ pre {
 .hljs-selector-tag,
 .hljs-deletion,
 .hljs-subst {
-  color: #a626a4;
+  color: #31708f;
 }
 .hljs-literal {
-  color: #0184bb;
+  color: #a94442;
 }
 .hljs-string,
 .hljs-regexp,
@@ -234,11 +234,11 @@ pre {
 .hljs-meta,
 .hljs-selector-id,
 .hljs-title {
-  color: #4078f2;
+  color: #a94442;
 }
 .hljs-built_in,
 .hljs-class .hljs-title {
-  color: #c18401;
+  color: #a94442;
 }
 .hljs-attr,
 .hljs-variable,


### PR DESCRIPTION
We have a main page that looks like this:
![image](https://user-images.githubusercontent.com/6759207/47142488-a39d7700-d2cb-11e8-9824-1cac972e8d7b.png)
Look at the "Declarative, composable code!" code example. 
It looks nice and uses the same colors the website theme uses.
With this tweak, other code snippets will also look like the one on the main page:
<img src="https://user-images.githubusercontent.com/6759207/47142591-e65f4f00-d2cb-11e8-8cf7-ae84209e1840.png" width="400">
Not that important, but I think this looks better.
