### PR TITLE
Add ReactiveGit WPF sample app

### DIFF
--- a/input/docs/resources/samples.md
+++ b/input/docs/resources/samples.md
@@ -14,7 +14,7 @@ Order: 15
 
 * **Dynamic.Trader** Additionally you absolutely must take https://github.com/RolandPheasant/Dynamic.Trader for a test-drive. So so good. 
 
-* **ReactiveGit** — ReactiveUI open-source app covering all ReactiveUI features including Binding and Routing https://github.com/kondaskondas/FirstsStepsRUI
+* **ReactiveGit** — ReactiveUI open-source app covering all ReactiveUI features including Binding and Routing https://github.com/glennawatson/reactivegit
 
 # Windows Forms
 

--- a/input/docs/resources/samples.md
+++ b/input/docs/resources/samples.md
@@ -14,7 +14,7 @@ Order: 15
 
 * **Dynamic.Trader** Additionally you absolutely must take https://github.com/RolandPheasant/Dynamic.Trader for a test-drive. So so good. 
 
-* **FirstStepsRUI**  ReactiveUI Binding and Routing tutorial covering all the `ReactiveUI.WPF` basics https://github.com/kondaskondas/FirstsStepsRUI
+* **ReactiveGit** — ReactiveUI open-source app covering all ReactiveUI features including Binding and Routing https://github.com/kondaskondas/FirstsStepsRUI
 
 # Windows Forms
 


### PR DESCRIPTION
@glennawatson made [an app covering almost all ReactiveUI features](https://github.com/glennawatson/ReactiveGit). I've learned a lot while reading it's source code. Wondering why isn't it on the samples page yet :) Thank you Glenn for such a great open-source app. 

Also I deliberately removed the "FirstStepsRUI" app because it's outdated and no longer maintained.