### PR TITLE
Use consistent colors

### DIFF
--- a/input/assets/css/override.less
+++ b/input/assets/css/override.less
@@ -292,7 +292,7 @@ pre {
 }
 
 .sidebar-menu li.selected {
-	background-color: #e3f1fc;
+	background-color: #f5f5f5;
 }
 
 .blockquote {
@@ -315,4 +315,11 @@ p a:hover {
 // fixes #175 issue
 .sidebar-menu li.active > a.expand {
 	left: -14px;
+}
+
+// rounded menu buttons
+.main-header .navbar .nav > li.active a {
+	background: #f5f5f5;
+	border-radius: 70px;
+	border: none;
 }


### PR DESCRIPTION
Before:

![image](https://user-images.githubusercontent.com/6759207/51445576-e716df80-1d17-11e9-9ea4-66b7359fa1e2.png)

After:

![image](https://user-images.githubusercontent.com/6759207/51445583-fbf37300-1d17-11e9-8b09-7f6609a581dd.png)

That light blue color looked odd a bit. Our logo uses primary blue and secondary lightgray colors, so let's use them instead of adding extra border/colors.