### PR TITLE
Hide horizontal scrollbar on Ubuntu

### DIFF
--- a/input/assets/css/override.less
+++ b/input/assets/css/override.less
@@ -382,6 +382,7 @@ p a:hover {
   font-size: 14px;
   line-height: 1.8em;
   margin-top: 20px;
+  overflow: hidden;
 }
 @media (max-width: 767px) {
   .branding-image {


### PR DESCRIPTION
They handle font scaling differently than Windows. Before:
![image](https://user-images.githubusercontent.com/6759207/51602946-5f98be80-1f19-11e9-85c1-3ac75df72642.png)

After: 
![image](https://user-images.githubusercontent.com/6759207/51602926-54459300-1f19-11e9-88cd-e94d03c83d76.png)
