### PR TITLE
Fix too large nav bar splitting into two lines

### DIFF
--- a/input/assets/css/override.less
+++ b/input/assets/css/override.less
@@ -410,3 +410,8 @@ pre .btn-copy {
 pre:hover .btn-copy {
   opacity: 1;
 }
+
+// Fix too long nav bar splitting into two lines
+.nav > li > a {
+  padding: 10px !important; 
+}


### PR DESCRIPTION
**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->

UI hotfix.

**What is the current behavior?**
<!-- You can also link to an open issue here. -->

On narrow screens we get the following behavior (one more tab has been added recently):

![image](https://user-images.githubusercontent.com/6759207/55319560-d0120d80-547d-11e9-9814-4dbdc13e72e8.png)


**What is the new behavior?**
<!-- If this is a feature change -->

![image](https://user-images.githubusercontent.com/6759207/55319531-bc66a700-547d-11e9-9bdb-f9acf84509b2.png)

**What might this PR break?**

Nothing.