### PR TITLE
/docs/handbook/oaph --> observable-as-property-helper

### DIFF
--- a/input/_redirects
+++ b/input/_redirects
@@ -24,3 +24,4 @@
 
 
 /blog/2018/05/dotnet-core-3-and-reactiveui⛵ /blog/2018/05/dotnet-core-3-and-reactiveui
+/docs/handbook/oaph /docs/handbook/observable-as-property-helper


### PR DESCRIPTION


**What kind of change does this PR introduce?**
docs update

**What is the current behavior?**
<!-- You can also link to an open issue here. -->
This page https://reactiveui.net/docs/handbook/commands/ says:
**Note** For performance based solutions you can also use the nameof() operator override of ToProperty() which won't use the Expression. Read more on ObservableAsPropertyHelper here.

The "here" link directs to "https://reactiveui.net/docs/handbook/oaph", which doesn't exist.


**What is the new behavior?**
<!-- If this is a feature change -->
 Need to change to /docs/handbook/observable-as-property-helper/


**What might this PR break?**
-


**Please check if the PR fulfills these requirements**
- [+] Tests for the changes have been added (for bug fixes / features)
- [+] Docs have been added / updated (for bug fixes / features)

**Other information**:

