### PR TITLE
simplify LoggingService and ConfigureLogging()

### DIFF
--- a/input/docs/guidelines/debugging/enable-framework-logging.md
+++ b/input/docs/guidelines/debugging/enable-framework-logging.md
@@ -3,27 +3,15 @@
 Debug information is written by the framework to Splat. By default, [splat ships with a null logger as "Debug.WriteLine" is stripped by the compiler when Splat is packaged](https://github.com/reactiveui/splat/issues/46). Wire in an implementation of `ILogger` such as the one below to see these messages:
 
 ```csharp
-public class LoggingService : ILogger
-{
-    public LogLevel Level { get; set; }
 
-    public void Write(string message, LogLevel logLevel)
+    public class LoggingService : ILogger
     {
-        if ((int)logLevel < (int)Level)
-        {
-            return;
-        }
+        public LogLevel Level { get; set; }
 
-        switch (logLevel)
+        public void Write([Splat.Localizable(false)] string message, LogLevel logLevel)
         {
-            case LogLevel.Warn:
-            case LogLevel.Error:
-            case LogLevel.Fatal:
-            case LogLevel.Debug:
-            case LogLevel.Info:
-            default:
-                Debug.WriteLine(message);
-                break;
+            if (logLevel >= Level)
+                System.Diagnostics.Debug.WriteLine(message);
         }
     }
 }
@@ -35,8 +23,7 @@ Then at your composition root, register your implementation
 public void ConfigureLogging()
 {
 #if DEBUG
-    var logger = new LoggingService { Level = LogLevel.Debug };
-    Locator.CurrentMutable.RegisterConstant(logger, typeof(ILogger));
+    Locator.CurrentMutable.RegisterConstant(new LoggingService { Level = LogLevel.Debug }, typeof(ILogger));
 #endif
 }
 ```


### PR DESCRIPTION
Simplifying LoggingService will make the code more readable, short and remove unnecessary extra comparison of logLevel local value and casting it to int. This may also make code more performant in a heavy-load scenario.

**What kind of change does this PR introduce?**
docs update



**What is the current behavior?**
<!-- You can also link to an open issue here. -->
too much code


**What is the new behavior?**
<!-- If this is a feature change -->
just the code we need


**What might this PR break?**
nothing, cause it's the docs


**Please check if the PR fulfills these requirements**
- [+] Tests for the changes have been added (for bug fixes / features)
- [+] Docs have been added / updated (for bug fixes / features)

**Other information**:

