### PR TITLE
Redirect to the new Installation page location

### DIFF
--- a/input/_redirects
+++ b/input/_redirects
@@ -25,3 +25,4 @@
 
 /blog/2018/05/dotnet-core-3-and-reactiveui⛵ /blog/2018/05/dotnet-core-3-and-reactiveui
 /docs/handbook/oaph /docs/handbook/observable-as-property-helper
+/docs/getting-started/installation/nuget-packages /docs/getting-started/installation


### PR DESCRIPTION
**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->

Resolve https://github.com/reactiveui/ReactiveUI/issues/2053 for older ReactiveUI packages.

**What is the current behavior?**
<!-- You can also link to an open issue here. -->

The Installation page has moved and the existing links to it [got broken](https://github.com/reactiveui/ReactiveUI/issues/2053).

**What is the new behavior?**
<!-- If this is a feature change -->

Now folks will get redirected to the new [Installation page location](https://reactiveui.net/docs/getting-started/installation/).

**What might this PR break?**

Nothing.
