### PR TITLE
.NET docs instead of Wikipedia

### DIFF
--- a/input/docs/reactive-programming/index.md
+++ b/input/docs/reactive-programming/index.md
@@ -18,7 +18,7 @@ public interface IObserver<in T>
 }
 ```
 
- Sometimes these last two can be omitted and you can just focus on defining the function for values. The "listening" to the stream is called subscribing. The functions we are defining are observers. The stream is the subject (or "observable") being observed. This is precisely the [Observer Design Pattern](https://en.wikipedia.org/wiki/Observer_pattern).
+ Sometimes these last two can be omitted and you can just focus on defining the function for values. The "listening" to the stream is called subscribing. The functions we are defining are observers. The stream is the subject (or "observable") being observed. This is precisely the [Observer Design Pattern](https://docs.microsoft.com/en-us/dotnet/standard/events/observer-design-pattern).
 
 ```cs
 public interface IObservable<out T>


### PR DESCRIPTION
Should we use the .NET docs for Observer Design Pattern?

**What kind of change does this PR introduce?**
Link switch for "Observer Design Pattern", link reader to the .NET docs of the subject instead of just Wikipedia page.



**What is the current behavior?**
_Observer Design Pattern_ links to [the subject on Wikipedia](https://en.wikipedia.org/wiki/Observer_pattern).

**What is the new behavior?**
_Observer Design Pattern_ links to [the subject in MSDN docs](https://docs.microsoft.com/en-us/dotnet/standard/events/observer-design-pattern).

**What might this PR break?**
Nothing. It's just a single link update.