### PR TITLE
Update Data Persistence docs

### DIFF
--- a/input/docs/handbook/data-persistence/index.md
+++ b/input/docs/handbook/data-persistence/index.md
@@ -17,7 +17,7 @@ public class SearchViewModel : ReactiveObject, ISearchViewModel
             .Select(query => !string.IsNullOrWhiteSpace(query));
 
         Search = ReactiveCommand.CreateFromTask(
-            () => searchService.Search(SearchQuery),
+            () => this.searchService.Search(SearchQuery),
             canSearch);
         
         _searchResults = Search.ToProperty(this, x => x.SearchResults);
@@ -135,32 +135,35 @@ You need to assign a function that creates a new AppState when there is none per
 For Android you need to implement the `Android.App.Application.IActivityLifecycleCallbacks` interface. Then add the following to the Application class:
 
 ```cs
-AutoSuspendHelper suspendHelper;
-
-public MyApplication(IntPtr javaReference, JniHandleOwnership transfer) : base (javaReference, transfer) { }
-
-public void OnActivityCreated(Activity activity, Bundle savedInstanceState) { }
-
-public void OnActivityDestroyed(Activity activity) { }
-
-public void OnActivityPaused(Activity activity) { }
-
-public void OnActivityResumed(Activity activity) { }
-
-public void OnActivitySaveInstanceState(Activity activity, Bundle outState) { }
-
-public void OnActivityStarted(Activity activity) { }
-
-public void OnActivityStopped(Activity activity) { }
-
-public override void OnCreate()
+public class AndroidApplication : Application, Android.App.Application.IActivityLifecycleCallbacks
 {
-    base.OnCreate();
-    suspendHelper = new AutoSuspendHelper(this);
-    
-    // Initialize the suspension driver after AutoSuspendHelper. 
-    RxApp.SuspensionHost.CreateNewAppState = () => new AppState();
-    RxApp.SuspensionHost.SetupDefaultSuspendResume(new AkavacheSuspensionDriver<AppState>());
+    private readonly AutoSuspendHelper suspendHelper;
+
+    public MyApplication(IntPtr javaReference, JniHandleOwnership transfer) : base(javaReference, transfer) { }
+
+    public void OnActivityCreated(Activity activity, Bundle savedInstanceState) { }
+
+    public void OnActivityDestroyed(Activity activity) { }
+
+    public void OnActivityPaused(Activity activity) { }
+
+    public void OnActivityResumed(Activity activity) { }
+
+    public void OnActivitySaveInstanceState(Activity activity, Bundle outState) { }
+
+    public void OnActivityStarted(Activity activity) { }
+
+    public void OnActivityStopped(Activity activity) { }
+
+    public override void OnCreate()
+    {
+        base.OnCreate();
+        suspendHelper = new AutoSuspendHelper(this);
+
+        // Initialize the suspension driver after AutoSuspendHelper. 
+        RxApp.SuspensionHost.CreateNewAppState = () => new AppState();
+        RxApp.SuspensionHost.SetupDefaultSuspendResume(new AkavacheSuspensionDriver<AppState>());
+    }
 }
 ```
 

--- a/input/docs/handbook/data-persistence/index.md
+++ b/input/docs/handbook/data-persistence/index.md
@@ -44,7 +44,7 @@ Make sure you `[IgnoreDataMember]` or `[JsonIgnore]` the HostScreen if your seri
 
 The `AutoSuspendHelper` class can help you in persisting your `AppState`. In the example below we create an `AppState` that generates a random new Guid and persists it. So every App installation has unique key persisted. There are several steps in creating an `AppState`. You need to have an object for the AppState itself (there are cases when it can be your root view model). You need a `SuspensionDriver` to persist the data. Then you need to wire it all together in the app composition root.
 
-## 1. Set Up the Suspension Driver
+## 1. Create the Suspension Driver
 
 Create a class that implements the `ISuspensionDriver` interface. There are several production-ready implementations below, especially the Akavache suspension driver that works on any platform supported by ReactiveUI. We highly recommend using [Akavache](https://github.com/reactiveui/akavache) suspension driver. Xamarin.iOS and Universal Windows Platform will replicate [Akavache](https://github.com/reactiveui/akavache) data to the cloud and synchronize it to all user devices on which the app is installed!
 
@@ -157,6 +157,8 @@ public override void OnCreate()
 {
     base.OnCreate();
     suspendHelper = new AutoSuspendHelper(this);
+    
+    // Initialize the suspension driver after AutoSuspendHelper. 
     RxApp.SuspensionHost.CreateNewAppState = () => new AppState();
     RxApp.SuspensionHost.SetupDefaultSuspendResume(new AkavacheSuspensionDriver<AppState>());
 }
@@ -176,6 +178,7 @@ public AppDelegate()
 
 public override bool FinishedLaunching(UIApplication application, NSDictionary launchOptions)
 {
+    // Initialize the suspension driver after AutoSuspendHelper.
     RxApp.SuspensionHost.CreateNewAppState = () => new AppState();
     RxApp.SuspensionHost.SetupDefaultSuspendResume(new AkavacheSuspensionDriver<AppState>());
     autoSuspendHelper.FinishedLaunching(application, launchOptions);
@@ -205,14 +208,16 @@ sealed partial class App : Application
     public App()
     {
         autoSuspendHelper = new AutoSuspendHelper(this);
+        
+        // Initialize the suspension driver after AutoSuspendHelper.
+        RxApp.SuspensionHost.CreateNewAppState = () => new AppState();
+        RxApp.SuspensionHost.SetupDefaultSuspendResume(new AkavacheSuspensionDriver<AppState>());
         InitializeComponent();
     }
 
     protected override void OnLaunched(LaunchActivatedEventArgs e)
     {
-        // Call OnLaunched on AutoSuspendHelper.
         autoSuspendHelper.OnLaunched(args);
-
         if (!(Window.Current.Content is Frame rootFrame))
         {
             rootFrame = new Frame();

--- a/input/docs/handbook/data-persistence/index.md
+++ b/input/docs/handbook/data-persistence/index.md
@@ -74,7 +74,7 @@ public class AkavacheSuspensionDriver<TAppState> : ISuspensionDriver where TAppS
 <details><summary>Newtonsoft.JSON Suspension Driver</summary>
 <p>
 
-Here is an implementation that uses [Newtonsoft.Json](https://github.com/JamesNK/Newtonsoft.Json) with `TypeNameHandling.All` json serialization setting for its persistense. The type information is included into the serialized JSON file, which means that `RoutingState` navigation stack consisting of `IRoutableViewModel`s could be restored. However, this driver isn't compatible with UWP. If you'd like to persist UWP state to a file, use `StorageFile` APIs instead of `System.IO.File`.
+Here is an implementation that uses [Newtonsoft.Json](https://github.com/JamesNK/Newtonsoft.Json) with `TypeNameHandling.All` json serialization setting for its persistense. The type information is included into the serialized JSON file, which means that `RoutingState` navigation stack consisting of `IRoutableViewModel`s could be restored. However, this driver isn't compatible with UWP. If you'd like to persist UWP state to a file, use `StorageFile` APIs instead of `System.IO.File`. You can also use [Xamarin.Essentials SecureStorage APIs](https://docs.microsoft.com/en-us/xamarin/essentials/secure-storage?tabs=android) to read and write serialized JSON objects, `SecureStorage.SetAsync` and  `SecureStorage.GetAsync`. 
 
 ```cs
 public class NewtonsoftJsonSuspensionDriver : ISuspensionDriver
@@ -264,3 +264,5 @@ The application state will be serialized and persisted using the `ISuspensionDri
 ```cs
 var appState = RxApp.SuspensionHost.GetAppState<AppState>();
 ```
+
+If you use your root view model as the app state object, then most likely you need to call the `GetAppState` method once in your composition root and assign the result to your root `DataContext` or `BindingContext`. When your application gets closed or suspended, the root view model state will be saved to the disc.

--- a/input/docs/handbook/data-persistence/index.md
+++ b/input/docs/handbook/data-persistence/index.md
@@ -233,6 +233,26 @@ sealed partial class App : Application
 }
 ```
 
+### WPF
+
+For WPF, add the following to your `App.xaml.cs` file:
+
+```cs
+public partial class App : Application
+{
+    private readonly AutoSuspendHelper autoSuspendHelper;
+
+    public App()
+    {
+        this.autoSuspendHelper = new AutoSuspendHelper(this);
+
+        // Initialize the suspension driver after AutoSuspendHelper.
+        RxApp.SuspensionHost.CreateNewAppState = () => new AppState();
+        RxApp.SuspensionHost.SetupDefaultSuspendResume(new AkavacheSuspensionDriver<AppState>());
+    }
+}
+```
+
 ## Retrieving the AppState
 
 The application state will be serialized and persisted using the `ISuspensionDriver` once the application gets closed, suspended or deactivated, depending on the platform. When you want to update data or retrieve data you can get the `AppState` object with the following code:

--- a/input/docs/handbook/data-persistence/index.md
+++ b/input/docs/handbook/data-persistence/index.md
@@ -135,11 +135,10 @@ You need to assign a function that creates a new AppState when there is none per
 For Android you need to implement the `Android.App.Application.IActivityLifecycleCallbacks` interface. Then add the following to the Application class:
 
 ```cs
-public class AndroidApplication : Application, Android.App.Application.IActivityLifecycleCallbacks
+[Activity(Label = "@string/app_name", Theme = "@style/AppTheme.NoActionBar", MainLauncher = true)]
+public class MainActivity : Activity, Android.App.Application.IActivityLifecycleCallbacks
 {
     private readonly AutoSuspendHelper suspendHelper;
-
-    public MyApplication(IntPtr javaReference, JniHandleOwnership transfer) : base(javaReference, transfer) { }
 
     public void OnActivityCreated(Activity activity, Bundle savedInstanceState) { }
 
@@ -155,9 +154,9 @@ public class AndroidApplication : Application, Android.App.Application.IActivity
 
     public void OnActivityStopped(Activity activity) { }
 
-    public override void OnCreate()
+    public override void OnCreate(Bundle bundle)
     {
-        base.OnCreate();
+        base.OnCreate(bundle);
         suspendHelper = new AutoSuspendHelper(this);
 
         // Initialize the suspension driver after AutoSuspendHelper. 

--- a/input/docs/handbook/data-persistence/index.md
+++ b/input/docs/handbook/data-persistence/index.md
@@ -172,30 +172,31 @@ public class AndroidApplication : Application, Android.App.Application.IActivity
 For iOS you need to add the following to the AppDelegate:
 
 ```cs
-readonly AutoSuspendHelper autoSuspendHelper;
-
-public AppDelegate()
+[Register("AppDelegate")]
+public class AppDelegate : UIApplicationDelegate
 {
-    autoSuspendHelper = new AutoSuspendHelper(this);
-}
+    private readonly AutoSuspendHelper autoSuspendHelper;
 
-public override bool FinishedLaunching(UIApplication application, NSDictionary launchOptions)
-{
-    // Initialize the suspension driver after AutoSuspendHelper.
-    RxApp.SuspensionHost.CreateNewAppState = () => new AppState();
-    RxApp.SuspensionHost.SetupDefaultSuspendResume(new AkavacheSuspensionDriver<AppState>());
-    autoSuspendHelper.FinishedLaunching(application, launchOptions);
-    return true;
-}
+    public AppDelegate() => autoSuspendHelper = new AutoSuspendHelper(this);
 
-public override void DidEnterBackground(UIApplication application)
-{
-    autoSuspendHelper.DidEnterBackground(application);
-}
+    public override bool FinishedLaunching(UIApplication application, NSDictionary launchOptions)
+    {
+        // Initialize the suspension driver after AutoSuspendHelper.
+        RxApp.SuspensionHost.CreateNewAppState = () => new AppState();
+        RxApp.SuspensionHost.SetupDefaultSuspendResume(new AkavacheSuspensionDriver<AppState>());
+        autoSuspendHelper.FinishedLaunching(application, launchOptions);
+        return true;
+    }
 
-public override void OnActivated(UIApplication application)
-{
-    autoSuspendHelper.OnActivated(application);
+    public override void DidEnterBackground(UIApplication application)
+    {
+        autoSuspendHelper.DidEnterBackground(application);
+    }
+
+    public override void OnActivated(UIApplication application)
+    {
+        autoSuspendHelper.OnActivated(application);
+    }
 }
 ```
 

--- a/input/docs/handbook/data-persistence/index.md
+++ b/input/docs/handbook/data-persistence/index.md
@@ -8,16 +8,23 @@ public class SearchViewModel : ReactiveObject, ISearchViewModel
     private readonly ISearchService searchService;
     private string searchQuery;
     
-    public SearchViewModel(ISearchService searchService) 
+    public SearchViewModel(ISearchService searchService = null) 
     { 
-        // Reactive commands and OAPHs initialization 
-        // logic that is deliberately omitted.     
+        this.searchService = searchService ?? Locator.Current.GetService<ISearchService>();
+
+        var canSearch = this
+            .WhenAnyValue(x => x.SearchQuery)
+            .Select(query => !string.IsNullOrWhiteSpace(query));
+
+        Search = ReactiveCommand.CreateFromTask(
+            () => searchService.Search(SearchQuery),
+            canSearch);
+        
+        _searchResults = Search.ToProperty(this, x => x.SearchResults);
     }
 
-    [IgnoreDataMember]
     public IEnumerable<SearchResults> SearchResults => _searchResults.Value;
      
-    [IgnoreDataMember]
     public ReactiveCommand<Unit, IEnumerable<SearchResults>> Search { get; }
     
     [DataMember]
@@ -29,57 +36,99 @@ public class SearchViewModel : ReactiveObject, ISearchViewModel
 }
 ```
 
-If you use Newtonsoft.Json library for serialization, you can replace the `[DataContract]` attribute with `[JsonObject]` attribute, use `[JsonIgnore]` instead of `[IgnoreDataMember]`, and use `[JsonProperty]` instead of `[DataMember]`, although Newtonsoft.Json fully supports [DataContract attributes](https://www.newtonsoft.com/json/help/html/DataContractAndDataMember.htm). Note, that `Newtonsoft.Json` uses opt-out approach by default, in contrast to `DataContractSerializer` which uses opt-in. Opt-out means that all public fields and properties will be serialized, unless you explicitly ignore them by placing `[IgnoreDataMember]` or `[JsonIgnore]` attributes, opt-in means the opposite.
+Surely, it's possible to use Newtonsoft.Json suspension driver and its attributes, such as `[JsonProperty]` or `[JsonIgnore]`, but remember, that in this case Newtonsoft.Json uses opt-out approach, in contrast to `DataContractSerializer` which uses opt-in. Opt-out means that all public fields and properties will be serialized, unless you explicitly ignore them by placing `[IgnoreDataMember]` or `[JsonIgnore]` attributes, opt-in means the opposite. Newtonsoft.Json fully supports [DataContract attributes](https://www.newtonsoft.com/json/help/html/DataContractAndDataMember.htm), but when `[DataContract]` attributes are used, it fallbacks to opt-in approach, similarly to `DataContractSerializer`.
+
+Make sure you `[IgnoreDataMember]` or `[JsonIgnore]` the HostScreen if your serializer uses opt-out approach, or you will get a circular reference. You should apply the pattern described above to every ViewModel which state is going to be serialized and restored. ViewModel serialization is Tricky Business, you have to decide what to serialize and what to recreate. Some stuff you should recalculate/reload when the app wakes up instead of trying to save it out.
 
 # Suspension
 
-Make sure you `[IgnoreDataMember]` (or `[JsonIgnore]`) the HostScreen or you will get a circular reference. You should apply the pattern described above to every ViewModel which state is going to be serialized and restored. ViewModel serialization is Tricky Business, you have to decide what to serialize and what to recreate. Some stuff you should recalculate/reload when the app wakes up instead of trying to save it out.
+The `AutoSuspendHelper` class can help you in persisting your `AppState`. In the example below we create an `AppState` that generates a random new Guid and persists it. So every App installation has unique key persisted. There are several steps in creating an `AppState`. You need to have an object for the AppState itself (there are cases when it can be your root view model). You need a `SuspensionDriver` to persist the data. Then you need to wire it all together in the app composition root.
 
-### AutoSuspendHelper
+## 1. Set Up the Suspension Driver
 
-The AutoSuspendHelper can help you in persisting your AppState. In this example we create an AppState that generates a random new Guid and persists it. So every App installation has unique key persisted. There are several steps in creating a AppState. You need to have a object for the AppState itself. You need a SuspensionDriver to persist the data. Then you need to wire it all together.
+Create a class that implements the `ISuspensionDriver` interface. There are several production-ready implementations below, especially the Akavache suspension driver that works on any platform supported by ReactiveUI. We highly recommend using [Akavache](https://github.com/reactiveui/akavache) suspension driver. Xamarin.iOS and Universal Windows Platform will replicate [Akavache](https://github.com/reactiveui/akavache) data to the cloud and synchronize it to all user devices on which the app is installed!
 
-### SuspensionDriver
+<details><summary>Akavache Platform Independent Suspension Driver</summary>
+<p>
 
-Here is an implementation that uses [Akavache](https://github.com/reactiveui/Akavache) for its persistense. The SuspensionDriver is platform independent, tested on iOS, Android, WPF, UWP, etc. 
+Here is an implementation that uses [Akavache](https://github.com/reactiveui/Akavache) for its persistense. The `SuspensionDriver` is platform independent, tested on iOS, Android, WPF, UWP, etc. 
 
 ```cs
 public class AkavacheSuspensionDriver<TAppState> : ISuspensionDriver where TAppState : class
 {
-    const string appStateKey = "appState";
+    private const string AppStateKey = "appState";
   
     public AkavacheSuspensionDriver() => BlobCache.ApplicationName = "Your Application Name";
 
-    public IObservable<Unit> InvalidateState() => BlobCache.UserAccount.InvalidateObject<TAppState>(appStateKey);
+    public IObservable<Unit> InvalidateState() => BlobCache.UserAccount.InvalidateObject<TAppState>(AppStateKey);
   
-    public IObservable<object> LoadState() => BlobCache.UserAccount.GetObject<TAppState>(appStateKey);
+    public IObservable<object> LoadState() => BlobCache.UserAccount.GetObject<TAppState>(AppStateKey);
 
-    public IObservable<Unit> SaveState(object state) => BlobCache.UserAccount.InsertObject(appStateKey, (TAppState)state);
+    public IObservable<Unit> SaveState(object state) => BlobCache.UserAccount.InsertObject(AppStateKey, (TAppState)state);
 }
 ```
 
-### AppState
+</p>
+</details>
 
-The AppState is an object with `DataContract` or `Newtonsoft.Json` notations, the AppState is platform independent.
+<details><summary>Newtonsoft.JSON Suspension Driver</summary>
+<p>
+
+Here is an implementation that uses [Newtonsoft.Json](https://github.com/JamesNK/Newtonsoft.Json) with `TypeNameHandling.All` json serialization setting for its persistense. The type information is included into the serialized JSON file, which means that `RoutingState` navigation stack consisting of `IRoutableViewModel`s could be restored. However, this driver isn't compatible with UWP. If you'd like to persist UWP state to a file, use `StorageFile` APIs instead of `System.IO.File`.
 
 ```cs
-[JsonObject]
+public class NewtonsoftJsonSuspensionDriver : ISuspensionDriver
+{
+    private readonly string _stateFilePath;
+    private readonly JsonSerializerSettings _settings = new JsonSerializerSettings
+    {
+        TypeNameHandling = TypeNameHandling.All
+    };
+
+    public NewtonsoftJsonSuspensionDriver(string stateFilePath) => _stateFilePath = stateFilePath;
+
+    public IObservable<Unit> InvalidateState()
+    {
+        if (File.Exists(_stateFilePath)) 
+            File.Delete(_stateFilePath);
+        return Observable.Return(Unit.Default);
+    }
+
+    public IObservable<object> LoadState()
+    {
+        var lines = File.ReadAllText(_stateFilePath);
+        var state = JsonConvert.DeserializeObject<object>(lines, _settings);
+        return Observable.Return(state);
+    }
+
+    public IObservable<Unit> SaveState(object state)
+    {
+        var lines = JsonConvert.SerializeObject(state, Formatting.Indented, _settings);
+        File.WriteAllText(_stateFilePath, lines);
+        return Observable.Return(Unit.Default);
+    }
+}
+```
+
+</p>
+</details>
+
+## 2. Define the AppState Object
+
+The `AppState` is an object with `DataContract` notations, the `AppState` is platform independent. You can use your root ViewModel as your `AppState` retrieving services from `Locator.Current.GetService<T>` for [dependency inversion feature](/docs/handbook/dependency-inversion/) to work.
+
+```cs
+[DataContract]
 public class AppState
 {
+    [DataMember]
     public string AuthToken = Guid.NewGuid().ToString();
 }
 ```
 
-# Wiring It Together
+## 3. Wire It Together
 
-### Platform independent
-
-You need to assign a function that creates a new AppState when there is none persisted. And the driver that is used for persistence. This can be done in the PCL for example, or, if it's an application for only one platform, in the application startup code.
-
-```cs
-RxApp.SuspensionHost.CreateNewAppState = () => new AppState();
-RxApp.SuspensionHost.SetupDefaultSuspendResume(new AkavacheSuspensionDriver<AppState>());
-```
+You need to assign a function that creates a new AppState when there is none persisted. And the driver that is used for persistence. This can be done in the PCL for example, or, if it's an application for only one platform, in the application startup code. Remember to call the `SetupDefaultSuspendResume` driver initializer only after initializing the platform-specific `AutoSuspendHelper`, otherwise the things won't get properly initialized. See the platform-specific examples below.
 
 ### Android
 
@@ -144,9 +193,44 @@ public override void OnActivated(UIApplication application)
 }
 ```
 
-### Retrieving the appstate
+### UWP
 
-When you want to store or retrieve data you can get the AppState object with the following code:
+For UWP, add somewhat like the following to your `App.xaml.cs` file:
+
+```cs
+sealed partial class App : Application
+{
+    private readonly AutoSuspendHelper autoSuspendHelper;
+
+    public App()
+    {
+        autoSuspendHelper = new AutoSuspendHelper(this);
+        InitializeComponent();
+    }
+
+    protected override void OnLaunched(LaunchActivatedEventArgs e)
+    {
+        // Call OnLaunched on AutoSuspendHelper.
+        autoSuspendHelper.OnLaunched(args);
+
+        if (!(Window.Current.Content is Frame rootFrame))
+        {
+            rootFrame = new Frame();
+            Window.Current.Content = rootFrame;
+        }
+        if (e.PrelaunchActivated == false)
+        {
+            if (rootFrame.Content == null)
+                rootFrame.Navigate(typeof(MainView), e.Arguments);
+            Window.Current.Activate();
+        }
+    }
+}
+```
+
+## Retrieving the AppState
+
+The application state will be serialized and persisted using the `ISuspensionDriver` once the application gets closed, suspended or deactivated, depending on the platform. When you want to update data or retrieve data you can get the `AppState` object with the following code:
 
 ```cs
 var appState = RxApp.SuspensionHost.GetAppState<AppState>();


### PR DESCRIPTION
**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->

Updates [Data Persistence](https://reactiveui.net/docs/handbook/data-persistence/) documentation page.

**What is the current behavior?**
<!-- You can also link to an open issue here. -->

`RxApp.SuspensionHost` isn't properly documented at this point IMHO, let's fix :)

**What is the new behavior?**
<!-- If this is a feature change -->

- [x] Add more information on suspension
- [x] Add `Newtonsoft.Json` driver example
- [x] Add UWP `AutoSuspendHelper` usage example
- [x] Add WPF `AutoSuspendHelper` usage example

**What might this PR break?**

Nothing.
