### PR TITLE
Updated initialization external DI code

### DIFF
--- a/input/docs/handbook/dependency-inversion/custom-dependency-inversion.md
+++ b/input/docs/handbook/dependency-inversion/custom-dependency-inversion.md
@@ -115,5 +115,6 @@ Locator.Current = resolver;
 
 From this point on calls `Locator.Current` will go against your custom implementation!
 
-Note: Some DI engines get locked away after they're being built and become immutable. For such services, the `Use<MatchingService>DependencyResolver` extension method (`UseAutofacDependencyResolver` in Autofac) must be called again on the locked container.
-In Microsoft DI, the built container is a completely different type. You should recall `UseMicrosoftDependencyResolver` on the `IServiceProvider` once it's ready, in case you are using an external framework to manage DI (i.e. [Generic Host](https://docs.microsoft.com/en-us/aspnet/core/fundamentals/host/generic-host?view=aspnetcore-2.2#configureservices)).
+Note: Some DI engines get locked away after they're being built and become immutable. For such services, the `Use<MatchingService>DependencyResolver` extension method (`UseAutofacDependencyResolver` in Autofac) must be called again on the locked container. See AutoFac [docs](https://github.com/reactiveui/splat/tree/master/src/Splat.Autofac).
+
+In Microsoft DI, the built container is a completely different type. You should recall `UseMicrosoftDependencyResolver` on the `IServiceProvider` once it's ready, in case you are using an external framework to manage DI (i.e. [Generic Host](https://docs.microsoft.com/en-us/aspnet/core/fundamentals/host/generic-host?view=aspnetcore-2.2#configureservices)), see the dedicated MS DI [docs](https://github.com/reactiveui/splat/tree/master/src/Splat.Microsoft.Extensions.DependencyInjection).

--- a/input/docs/handbook/dependency-inversion/custom-dependency-inversion.md
+++ b/input/docs/handbook/dependency-inversion/custom-dependency-inversion.md
@@ -104,7 +104,8 @@ public class AutofacDependencyRegistrar
 ## Set the Locator.Current to your implementation
 
 ```csharp
-var resolver = new AutofacDependencyResolver(container);
+container.UseAutofacDependencyResolver();
+var resolver = Locator.CurrentMutable;
 // These Initialize methods will add ReactiveUI platform registrations to your container
 // They MUST be present if you override the default Locator
 resolver.InitializeSplat();

--- a/input/docs/handbook/dependency-inversion/custom-dependency-inversion.md
+++ b/input/docs/handbook/dependency-inversion/custom-dependency-inversion.md
@@ -114,3 +114,6 @@ Locator.Current = resolver;
 ```
 
 From this point on calls `Locator.Current` will go against your custom implementation!
+
+Note: Some DI engines get locked away after they're being built and become immutable. For such services, the `Use<MatchingService>DependencyResolver` extension method (`UseAutofacDependencyResolver` in Autofac) must be called again on the locked container.
+In Microsoft DI, the built container is a completely different type. You should recall `UseMicrosoftDependencyResolver` on the `IServiceProvider` once it's ready, in case you are using an external framework to manage DI (i.e. [Generic Host](https://docs.microsoft.com/en-us/aspnet/core/fundamentals/host/generic-host?view=aspnetcore-2.2#configureservices)).


### PR DESCRIPTION
See: https://github.com/reactiveui/splat/pull/380

Just improved the registration bit to use our dedicated ex. methods instead of user instantiating the resolver on their own.