### PR TITLE
Fix Win32Exception on .NET Core on Windows

### DIFF
--- a/input/docs/getting-started/index.md
+++ b/input/docs/getting-started/index.md
@@ -158,7 +158,13 @@ public class NugetDetailsViewModel : ReactiveObject
     {
         _metadata = metadata;
         _defaultUrl = new Uri("https://git.io/fAlfh");
-        OpenPage = ReactiveCommand.Create(() => { Process.Start(ProjectUrl.ToString()); });
+        OpenPage = ReactiveCommand.Create(() =>
+        {
+            Process.Start(new ProcessStartInfo(this.ProjectUrl.ToString())
+            {
+                UseShellExecute = true
+            });
+        });
     }
     
     public Uri IconUrl => _metadata.IconUrl ?? _defaultUrl;


### PR DESCRIPTION
- On .NET Core 3.0 on Windows you will get a Win32Exception when you try to open any URL, because of this https://github.com/dotnet/corefx/issues/10361
   ```
   System.ComponentModel.Win32Exception (2): The system cannot find the file specified.
      at System.Diagnostics.Process.StartWithCreateProcess(ProcessStartInfo startInfo)
      at System.Diagnostics.Process.Start()
      at System.Diagnostics.Process.Start(ProcessStartInfo startInfo)
      at System.Diagnostics.Process.Start(String fileName)
      at ReactiveDemo.NugetDetailsViewModel.<.ctor>b__2_0() in C:\temp\ReactiveDemo\ReactiveDemo\ReactiveDemo\NugetDetailsViewModel.cs:line 22
      at ReactiveUI.ReactiveCommand.<>c__DisplayClass0_0.<Create>b__1(IObserver`1 observer) in d:\a\1\s\src\ReactiveUI\ReactiveCommand\ReactiveCommand.cs:line 108
      at System.Reactive.Linq.QueryLanguage.CreateWithDisposableObservable`1.SubscribeCore(IObserver`1 observer) in d:\a\1\s\Rx.NET\Source\src\System.Reactive\Linq\QueryLanguage.Creation.cs:line 35
      at System.Reactive.ObservableBase`1.Subscribe(IObserver`1 observer) in d:\a\1\s\Rx.NET\Source\src\System.Reactive\ObservableBase.cs:line 58
   ```

- The proposed change was tested on .NET Core on Windows but *should* work anywhere.

