### PR TITLE
Use Service "Locator" instead of Service "Location"

### DIFF
--- a/input/docs/handbook/dependency-inversion/index.md
+++ b/input/docs/handbook/dependency-inversion/index.md
@@ -4,9 +4,9 @@ Dependency resolution is very useful for moving logic that would normally have t
 
 Dependency resolution is a feature built into the core framework, which allows libraries and ReactiveUI itself to use classes that are in other libraries without taking a direct reference to them. This is quite useful for cross-platform applications, as it allows portable code to use non-portable APIs, as long as they can be described via an Interface.
 
-ReactiveUI's use of dependency resolution can more properly be called the Service Location pattern. If service location doesn't fit your situation then have a look at how to do composition root.
+ReactiveUI's use of dependency resolution can more properly be called the Service Locator pattern. If the locator pattern doesn't fit your situation then have a look at how to do composition root.
 
-Since ReactiveUI 6, [Splat](https://github.com/reactiveui/splat) is used by ReactiveUI for service location and dependency injection. Earlier versions included a RxUI resolver. If you come across samples for RxUI versions earlier than 6, you should replace references to `RxApp.DependencyResolver` with `Locator.Current` and `RxApp.MutableResolver` with `Locator.CurrentMutable`.
+Since ReactiveUI 6, [Splat](https://github.com/reactiveui/splat) is used by ReactiveUI for service locator and dependency injection. Earlier versions included a RxUI resolver. If you come across samples for RxUI versions earlier than 6, you should replace references to `RxApp.DependencyResolver` with `Locator.Current` and `RxApp.MutableResolver` with `Locator.CurrentMutable`.
 
 ## Why Splat?
 


### PR DESCRIPTION
<!-- Please read first the [Contribute](https://github.com/reactiveui/reactiveui#contribute) section of the README file -->

**What are the main goals of this change?**
- [x] Better readability (style, grammar, spelling...)
- [ ] Content correction (accuracy, wrong information...)
- [ ] New content


**Is this change related to any reported issue? (Optional)**
<!-- Link to issues here. -->


**Notes (Optional)**

Since the common name for this pattern is Service _locator_ (the implementation file is also called `Locator` though - https://github.com/reactiveui/splat/blob/master/src/Splat/ServiceLocation/Locator.cs), so I think renaming it to this will reduce confusion by a bit (I was initially confused by the naming...). 

_Note that I didn't change the wordings in the original quote from Anaïs Betts._