### PR TITLE
Remove possession

### DIFF
--- a/input/docs/guidelines/framework/asynchronous-commands.md
+++ b/input/docs/guidelines/framework/asynchronous-commands.md
@@ -1,6 +1,6 @@
 # Asynchronous Commands
 
-Prefer using async `ReactiveCommand`s over the more basic `ReactiveCommand` for all but the most simple tasks. In ReactiveUI, you should never put Interesting™ code inside the Subscribe block - Subscribe is solely to log the result of operations, or to wire up properties to other properties.
+Prefer using async `ReactiveCommand` over the more basic `ReactiveCommand` for all but the most simple tasks. In ReactiveUI, you should never put Interesting™ code inside the Subscribe block - Subscribe is solely to log the result of operations, or to wire up properties to other properties.
 
 ## Do
 

--- a/input/docs/guidelines/framework/asynchronous-commands.md
+++ b/input/docs/guidelines/framework/asynchronous-commands.md
@@ -1,6 +1,6 @@
 # Asynchronous Commands
 
-Prefer using async `ReactiveCommand`'s over the more basic `ReactiveCommand` for all but the most simple tasks. In ReactiveUI, you should never put Interesting™ code inside the Subscribe block - Subscribe is solely to log the result of operations, or to wire up properties to other properties.
+Prefer using async `ReactiveCommand`s over the more basic `ReactiveCommand` for all but the most simple tasks. In ReactiveUI, you should never put Interesting™ code inside the Subscribe block - Subscribe is solely to log the result of operations, or to wire up properties to other properties.
 
 ## Do
 


### PR DESCRIPTION
This wanted to denote plural here, not possession, but also if we denote plural, then we would need to denote plural in the following "`ReactiveCommand`", too. I think removing the pluralization altogether avoids the awkward "s" after the codeblock.