### PR TITLE
Added the this. to TheText setter

### DIFF
--- a/input/docs/handbook/data-binding/windows-store.md
+++ b/input/docs/handbook/data-binding/windows-store.md
@@ -11,7 +11,7 @@ public class TheViewModel : ReactiveObject
     public string TheText
     {
         get => theText;
-        set => RaiseAndSetIfChanged(ref theText, value);
+        set => this.RaiseAndSetIfChanged(ref theText, value);
     }
     
     ReactiveCommand<Unit,Unit> TheTextCommand { get; set; }


### PR DESCRIPTION
will all the current libraries and frameworks, with out the `this` in front of `RaiseAndSetIfChanged(ref theText, value):` I had a compiler error that my TheViewModel did not have matching signature.
I noticed all the other examples included the `this.` so I added it here and it worked.

<!-- Please read first the [Contribute](https://github.com/reactiveui/reactiveui#contribute) section of the README file -->

**What are the main goals of this change?**
- [ ] Better readability (style, grammar, spelling...)
- [x] Content correction (accuracy, wrong information...)
- [ ] New content


**Is this change related to any reported issue? (Optional)**
not that I'm aware of


**Notes (Optional)**

To be honest I'm not totally sure why the `this` is required. In fact it kinda bugs me that it is required to compile.  As I understand inheritance the `this` shouldn't be required.  But since who ever made up the documentation for the other frameworks had explicitly included it, and since that change allowed the compilation to work, I figured it wouldn't hurt to add it for who ever follows behind me and tries to get this Hello World to work.
