### PR TITLE
Remove greater and less than signs around links

### DIFF
--- a/input/docs/getting-started/compelling-example.md
+++ b/input/docs/getting-started/compelling-example.md
@@ -117,7 +117,7 @@ We also need a NuGet client library in this tutorial, and we are going to instal
         {
             var providers = new List<Lazy<INuGetResourceProvider>>();
             providers.AddRange(Repository.Provider.GetCoreV3()); // Add v3 API support
-            var packageSource = new PackageSource("<https://api.nuget.org/v3/index.json>");
+            var packageSource = new PackageSource("https://api.nuget.org/v3/index.json");
             var source = new SourceRepository(packageSource, providers);
     
             var filter = new SearchFilter(false);
@@ -145,7 +145,7 @@ Let's now create a `NugetDetailsViewModel.cs` class that will wrap out NuGet met
         public NugetDetailsViewModel(IPackageSearchMetadata metadata)
         {
             _metadata = metadata;
-            _defaultUrl = new Uri("<https://git.io/fAlfh>");
+            _defaultUrl = new Uri("https://git.io/fAlfh");
             OpenPage = ReactiveCommand.Create(() =>
             {
                 Process.Start(new ProcessStartInfo(this.ProjectUrl.ToString())
@@ -191,12 +191,12 @@ Then we declare the XAML for our Main Window.
     <reactiveui:ReactiveWindow 
         x:Class="ReactiveDemo.MainWindow"
         x:TypeArguments="reactivedemo:AppViewModel"
-        xmlns="<http://schemas.microsoft.com/winfx/2006/xaml/presentation>"
-        xmlns:x="<http://schemas.microsoft.com/winfx/2006/xaml>"
-        xmlns:d="<http://schemas.microsoft.com/expression/blend/2008>"
-        xmlns:mc="<http://schemas.openxmlformats.org/markup-compatibility/2006>"
+        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+        xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
         xmlns:reactivedemo="clr-namespace:ReactiveDemo"
-        xmlns:reactiveui="<http://reactiveui.net>"
+        xmlns:reactiveui="http://reactiveui.net"
         Title="NuGet Browser" Height="450" Width="800"
         mc:Ignorable="d">
         <Grid Margin="12">
@@ -270,9 +270,9 @@ We are now going to create a view for our `NugetDetailsViewModel`. Create a new 
       x:Class="ReactiveDemo.NugetDetailsView"
       xmlns:reactiveDemo="clr-namespace:ReactiveDemo"
       x:TypeArguments="reactiveDemo:NugetDetailsViewModel"
-      xmlns:reactiveui="<http://reactiveui.net>"
-      xmlns="<http://schemas.microsoft.com/winfx/2006/xaml/presentation>"
-      xmlns:x="<http://schemas.microsoft.com/winfx/2006/xaml>">
+      xmlns:reactiveui="http://reactiveui.net"
+      xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+      xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
       <Grid>
           <Grid.ColumnDefinitions>
               <ColumnDefinition Width="Auto" />
@@ -376,10 +376,10 @@ Now we should initialize the DataContext of our MainWindow by assigning an insta
 Finally, we need to create XAML markup for our app.
 
     <Window x:Class="ReactiveDemo.MainWindow"
-            xmlns="<http://schemas.microsoft.com/winfx/2006/xaml/presentation>"
-            xmlns:x="<http://schemas.microsoft.com/winfx/2006/xaml>"
-            xmlns:d="<http://schemas.microsoft.com/expression/blend/2008>"
-            xmlns:mc="<http://schemas.openxmlformats.org/markup-compatibility/2006>"
+            xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+            xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+            xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+            xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
             Title="NuGet Browser" mc:Ignorable="d" Height="450" Width="800">
         <Window.Resources>
             <ResourceDictionary>


### PR DESCRIPTION
**What are the main goals of this change?**
- [ ] Better readability (style, grammar, spelling...)
- [x] Content correction (accuracy, wrong information...)
- [ ] New content

**Notes (Optional)**
Remove all less and greater than signs (`<`, `>`) around http-links in code.
Invalid syntax doesn't compile.