### PR TITLE
#416 point to reactiveui.testing instead of testutils

### DIFF
--- a/input/docs/handbook/testing/index.md
+++ b/input/docs/handbook/testing/index.md
@@ -42,7 +42,7 @@ public interface ISchedulerProvider
 
 # Unit Tests
 
-Then, in unit tests project, you can inject a `TestScheduler` instance that allows you to play with time. There are a few more utility classes to help handle testing, see details on the [API documentation site](https://reactiveui.net/api/reactiveui.testing/testutils/). 
+Then, in unit tests project, you can inject a `TestScheduler` instance that allows you to play with time. There are a few more utility classes to help handle testing, see details on the [API documentation site](https://reactiveui.net/api/reactiveui.testing/). 
 
 ```cs
 new TestScheduler().With(scheduler =>


### PR DESCRIPTION
closes #416

replaces 404 link to https://reactiveui.net/api/reactiveui.testing/testutils with https://reactiveui.net/api/reactiveui.testing/