### PR TITLE
Update Store name and remove old warning

### DIFF
--- a/input/docs/handbook/data-binding/index.md
+++ b/input/docs/handbook/data-binding/index.md
@@ -26,7 +26,7 @@ In order to use bindings in the View, you must first implement `IViewFor<TViewMo
 
 For a detailed overview of the bindings on each platform, see the following sections:
 
-* [Universal Windows Platform](./windows-store)
+* [Universal Windows Platform](./microsoft-store)
 
 * [Xamarin.Forms](./xamarin-forms)
 

--- a/input/docs/handbook/data-binding/microsoft-store.md
+++ b/input/docs/handbook/data-binding/microsoft-store.md
@@ -1,7 +1,5 @@
 For Universal Windows applications, you need to implement `IViewFor<T>` by hand and ensure that ViewModel is a `DependencyProperty`. Also, always dispose bindings via [WhenActivated](../when-activated), or else the bindings leak memory. You can easily use the new `x:Bind` syntax with ReactiveUI. All you need is doing `{x:Bind ViewModel.TheText, Mode=OneWay}`. Remember, that `x:Bind` bindings are `OneTime` by default, not `OneWay`, so in certain scenarios you need to specify the `OneWay` mode explicitly.
 
-> **Warning** There are known issues with compiling apps that use `Bind` and `BindCommand` methods using .NET Native toolchain. You can track those issues and find a temporary solution here — https://github.com/reactiveui/ReactiveUI/issues/1750
-
 The goal in the example below is to two-way bind `TheText` property of `TheViewModel` to the TextBox and one-way bind `TheText` property to the TextBlock, so the TextBlock updates when the user types text into the TextBox.
   
 ```csharp


### PR DESCRIPTION
<!-- Please read first the [Contribute](https://github.com/reactiveui/reactiveui#contribute) section of the README file -->

**What are the main goals of this change?**
- [ ] Better readability (style, grammar, spelling...)
- [X] Content correction (accuracy, wrong information...)
- [ ] New content


**Is this change related to any reported issue? (Optional)**
https://github.com/reactiveui/ReactiveUI/issues/1750
https://github.com/reactiveui/ReactiveUI/pull/1937

**Notes**
The .NET Native compilation issues appear to have been resolved via the above PR.

The "Windows Store" was also renamed to the "Microsoft Store" in 2017. Although the section should probably just be called "Universal Windows Platform / WinUI" now.