### PR TITLE
Fix GitHub logo truncation #394

### DIFF
--- a/input/_Master.cshtml
+++ b/input/_Master.cshtml
@@ -89,7 +89,7 @@
             
                     <!-- Collect the nav links, forms, and other content for toggling -->
                     <div class="collapse navbar-collapse" id="navbar-collapse">
-                        <ul class="nav navbar-nav navbar-right">
+                        <ul class="nav navbar-nav navbar-right no-margin">
                             @Html.Partial("_Navbar") 
                         </ul>       
                     </div>


### PR DESCRIPTION
<!-- Please read first the [Contribute](https://github.com/reactiveui/reactiveui#contribute) section of the README file -->

**What are the main goals of this change?**

Fixed a visual bug on our main page, which has lead to GitHub logo truncation:

![image](https://user-images.githubusercontent.com/6759207/88165552-8cb55280-cc1e-11ea-85c6-4d68f5d2cb53.png)
**Is this change related to any reported issue? (Optional)**
<!-- Link to issues here. -->

This bug was reported in https://github.com/reactiveui/website/issues/394

**Notes**

It looks like this now:
![image](https://user-images.githubusercontent.com/6759207/88165654-b2daf280-cc1e-11ea-9374-31c116f2ad50.png)
