### PR TITLE
Fix dependency resolver registration example

### DIFF
--- a/input/assets/css/override.less
+++ b/input/assets/css/override.less
@@ -429,3 +429,8 @@ pre:hover .btn-copy {
   color: white;
   opacity: 0.7;
 }
+
+// Fix scroll-to-top button interactivity.
+#return-to-top {
+  z-index: 999;
+}

--- a/input/docs/handbook/dependency-inversion/custom-dependency-inversion.md
+++ b/input/docs/handbook/dependency-inversion/custom-dependency-inversion.md
@@ -78,9 +78,9 @@ public class AutofacDependencyResolver : IMutableDependencyResolver
 ### Set the Locator.Current to Your Implementation
 
 ```csharp
-var container = new ContainerBuilder();
+var containerBuilder = new ContainerBuilder();
 // Register things to the Autofac container...
-container.UseAutofacDependencyResolver();
+Locator.SetLocator(new AutofacDependencyResolver(containerBuilder.Build()));;
 Locator.CurrentMutable.InitializeSplat();
 Locator.CurrentMutable.InitializeReactiveUI();
 // These InitializeX() methods will add ReactiveUI platform 

--- a/input/docs/handbook/dependency-inversion/custom-dependency-inversion.md
+++ b/input/docs/handbook/dependency-inversion/custom-dependency-inversion.md
@@ -1,8 +1,41 @@
 # Override Default Depenedency Inversion Container
 
-We understand that some developers would prefer to use their favorite dependency inversion container. ReactiveUI allows for this by implementing `IMutableDependencyResolver`. Once this class has been implemented you simply need to assign it to `Locator` via `Locator.SetLocator()`. [Splat](https://github.com/reactiveui/splat#dependency-resolver-packages) includes ready to use packages containing dependency resolver implementations for `Autofac`, `DryIoc`, `Microsoft.Extensions.DependencyInjection`, `Ninject`, and `SimpleInjector`, see [the documentation](https://github.com/reactiveui/splat#dependency-resolver-packages) for more info.
+We understand that some developers would prefer to use their favorite dependency inversion container. ReactiveUI allows for this by implementing `IMutableDependencyResolver`. Once this class has been implemented you simply need to assign it to `Locator` via `Locator.SetLocator()`. 
 
-### Implement a custom `IMutableDependencyResolver`
+## Use a Dependency Resolver Package
+
+ReactiveUI uses [Splat](https://github.com/reactiveui/splat) for service location, and Splat can be thought of as a ReactiveUI utility extracted into a separate package. Splat includes ready to use [packages containing dependency resolver implementations](https://github.com/reactiveui/splat#dependency-resolver-packages) for `Autofac`, `DryIoc`, `Microsoft.Extensions.DependencyInjection`, `Ninject`, and `SimpleInjector`, see [the documentation page](https://github.com/reactiveui/splat#dependency-resolver-packages) for more info.
+
+Now let's consider a simple example. Assume we wish to use `Splat.Autofac` dependency resolver package. We are going to replace the default container used by ReactiveUI with `Autofac`. To get started, we install the `Splat.Autofac` package via NuGet package manager or via .NET Core CLI:
+
+```sh
+dotnet add package Splat.Autofac
+```
+
+Next, we build a new `Autofac` container and register all the required dependencies into it. Next, we add a call to `UseAutofacDependencyResolver` which is an extension method inside the `Splat.Autofac` namespace. This method becomes available once we install the `Splat.Autofac` package into our project. We write the following code:
+
+```cs
+// Build a new Autofac container.
+var container = new ContainerBuilder();
+container.RegisterType<MainPage>().As<IViewFor<MainViewModel>>();
+
+// Use Autofac for ReactiveUI dependency resolution.
+// After we call the method below, Locator.Current and
+// Locator.CurrentMutable start using Autofac locator.
+container.UseAutofacDependencyResolver();
+
+// These .InitializeX() methods will add ReactiveUI platform 
+// registrations to your container. They MUST be present if
+// you *override* the default Locator.
+Locator.CurrentMutable.InitializeSplat();
+Locator.CurrentMutable.InitializeReactiveUI();
+```
+
+> **Note** Call `Locator.CurrentMutable.InitializeSplat()` and `Locator.CurrentMutable.InitializeReactiveUI()` *only if you are going to override* the default Splat locator. Otherwise *you don't need to explicitly call these two methods*, as ReactiveUI calls these methods implicitly for you.
+
+## Implement a Custom `IMutableDependencyResolver`
+
+If you are going to write a custom dependency resolver for Splat, then implement the `IMutableDependencyResolver` interface and add a call to `Locator.SetLocator`. This will replace the default locator implementation with your own.
 
 <details><summary>IMutableDependencyResolver implementation against Autofac (example)</summary>
 
@@ -75,17 +108,19 @@ public class AutofacDependencyResolver : IMutableDependencyResolver
 ```
 </details>
 
-### Set the Locator.Current to Your Implementation
-
 ```csharp
+// Build a new Autofac container.
 var containerBuilder = new ContainerBuilder();
-// Register things to the Autofac container...
-Locator.SetLocator(new AutofacDependencyResolver(containerBuilder.Build()));;
-Locator.CurrentMutable.InitializeSplat();
-Locator.CurrentMutable.InitializeReactiveUI();
+container.RegisterType<MainPage>().As<IViewFor<MainViewModel>>();
+
+// Use your own IMutableDependencyResolver implementation.
+Locator.SetLocator(new AutofacDependencyResolver(containerBuilder.Build()));
+
 // These InitializeX() methods will add ReactiveUI platform 
 // registrations to your container. They MUST be present if
 // you override the default Locator.
+Locator.CurrentMutable.InitializeSplat();
+Locator.CurrentMutable.InitializeReactiveUI();
 ``` 
 
 From this point on calls `Locator.Current` will go against your custom implementation!


### PR DESCRIPTION
<!-- Please read first the [Contribute](https://github.com/reactiveui/reactiveui#contribute) section of the README file -->

**What are the main goals of this change?**
- [ ] Better readability (style, grammar, spelling...)
- [x] Content correction (accuracy, wrong information...)
- [x] New content

After proofreading the DI docs one more time, noticed that we aren't showing how to use `Locator.SetLocator`, and are showing the code from the `Splat.Autofac` package instead. Assuming IoC container support packages are documented in https://github.com/reactiveui/splat#dependency-resolver-packages (and we are referencing that documentation page here https://www.reactiveui.net/docs/handbook/dependency-inversion/custom-dependency-inversion), probably worth showing how to implement a custom dependency resolver from scratch.
