### PR TITLE
Fix the broken 'debugging tip' link

### DIFF
--- a/input/docs/guidelines/debugging/disable-just-my-code.md
+++ b/input/docs/guidelines/debugging/disable-just-my-code.md
@@ -6,5 +6,7 @@ In settings of Visual Studio, disable the [Just My Code](https://msdn.microsoft.
 ## Enable Stop on First Chance Exceptions
 This is like Rx debugging pro-tip #1:
 
-http://blogs.msdn.com/b/davidklinems/archive/2005/07/18/440150.aspx
+> In Visual Studio, when exceptions are thrown or end up unhandled, the debugger can help you debug these by breaking just like it breaks when a breakpoint is hit. In this blog post we will look at the different classifications of exceptions and how to configure when the debugger will break for those exceptions.
+
+https://devblogs.microsoft.com/devops/understanding-exceptions-while-debugging-with-visual-studio
 


### PR DESCRIPTION
<!-- Please read first the [Contribute](https://github.com/reactiveui/reactiveui#contribute) section of the README file -->

**What are the main goals of this change?**
- [ ] Better readability (style, grammar, spelling...)
- [x] Content correction (accuracy, wrong information...)
- [ ] New content


**Is this change related to any reported issue? (Optional)**
<!-- Link to issues here. -->
fixes #400 

**Notes (Optional)**
I found the [original blog post](https://docs.microsoft.com/en-us/archive/blogs/davidklinems/how-to-stop-on-first-chance-exceptions-visual-studio-net-2003) (from 2005) but then was able to dig up a more up-to-date and elaborate version [here](https://devblogs.microsoft.com/devops/understanding-exceptions-while-debugging-with-visual-studio/) (2015).