### PR TITLE
Fix broken links and reference AndroidX

### DIFF
--- a/input/docs/guidelines/platform/xamarin-android.md
+++ b/input/docs/guidelines/platform/xamarin-android.md
@@ -1,7 +1,7 @@
 Title: Xamarin Android
 ---
 
-Ensure that you install `ReactiveUI.AndroidSupport` into your applications.
+Ensure that you install either `ReactiveUI.AndroidX` or `ReactiveUI.AndroidSupport` into your applications.
 
 Your viewmodels should inherit from `ReactiveObject`
 
@@ -30,23 +30,17 @@ Don't use eventhandlers, use the extension methods shipped in `reactiveui.events
 
 Use your normal Android concepts that you would usually use in Android development, we have some base classes which you should use as they expose observables such as `Changed`, `Changing` and `Deactivated` that can be used for composition.
 
-- https://reactiveui.net/api/reactiveui.androidsupport/reactiveappcompatactivity_1/
-- https://reactiveui.net/api/reactiveui/reactiveactivity/
-- https://reactiveui.net/api/reactiveui/reactivefragment/
-- https://reactiveui.net/api/reactiveui.android.support/reactiverecyclerviewadapter_1/
-- https://reactiveui.net/api/reactiveui.androidsupport/reactiveactionbaractivity
-- https://reactiveui.net/api/reactiveui.androidsupport/reactivefragment/
-- https://reactiveui.net/api/reactiveui.androidsupport/reactivedialogfragment/
-- https://reactiveui.net/api/reactiveui/reactivefragmentactivity/
-- https://reactiveui.net/api/reactiveui/reactivelistadapter_1/
-- https://reactiveui.net/api/reactiveui/reactivepageradapter_1/
-- https://reactiveui.net/api/reactiveui/reactivepreferencefragment/
-- https://reactiveui.net/api/reactiveui/reactivepreferenceactivity/
+- [ReactiveActivity](https://reactiveui.net/api/reactiveui/reactiveactivity_1/)
+- [ReactiveFragment](https://reactiveui.net/api/reactiveui/reactivefragment_1/)
+- [ReactivePreferenceFragment](https://reactiveui.net/api/reactiveui/reactivepreferencefragment_1/)
+- [ReactivePreferenceActivity](https://reactiveui.net/api/reactiveui/reactivepreferenceactivity_1/)
+- [ReactiveUI.AndroidSupport](https://www.reactiveui.net/api/reactiveui.androidsupport/)
+- [ReactiveUI.AndroidX](https://www.reactiveui.net/api/reactiveui.androidx/)
 
 There's also some extension methods which will make your life easier
 
-- https://reactiveui.net/api/reactiveui.androidsupport/controlfetchermixin/
-- https://reactiveui.net/api/reactiveui/sharedpreferencesextensions/
-- https://reactiveui.net/api/reactiveui/usbmanagerextensions/
-- https://reactiveui.net/api/reactiveui/androidobservableforwidgets/
-- https://reactiveui.net/api/reactiveui/flexiblecommandbinder/
+- [ControlFetcherMixin](https://reactiveui.net/api/reactiveui.androidsupport/controlfetchermixin/)
+- [SharedPreferencesExtensions](https://reactiveui.net/api/reactiveui/sharedpreferencesextensions/)
+- [UsbManagerExtensions](https://reactiveui.net/api/reactiveui/usbmanagerextensions/)
+- [AndroidObservableForWidgets](https://reactiveui.net/api/reactiveui/androidobservableforwidgets/)
+- [FlexibleCommandBinder](https://reactiveui.net/api/reactiveui/flexiblecommandbinder/)


### PR DESCRIPTION
- Use class/namespace names to display links (easier to browse).
- Reference the API namespace url instead of each individual class (less future maintenance required). The exception is the classes included in the core ReactiveUI project because those don't have a sub-namespace.

<!-- Please read first the [Contribute](https://github.com/reactiveui/reactiveui#contribute) section of the README file -->

**What are the main goals of this change?**
- [x] Better readability (style, grammar, spelling...)
- [x] Content correction (accuracy, wrong information...)
- [x] New content


**Is this change related to any reported issue? (Optional)**
<!-- Link to issues here. -->


**Notes (Optional)**

Broken links:
- https://reactiveui.net/api/reactiveui.android.support/reactiverecyclerviewadapter_1/
- https://reactiveui.net/api/reactiveui.androidsupport/reactiveactionbaractivity
- https://reactiveui.net/api/reactiveui/reactivefragmentactivity/	
- https://reactiveui.net/api/reactiveui/reactivelistadapter_1/	
- https://reactiveui.net/api/reactiveui/reactivepageradapter_1/