### PR TITLE
docs: Document the ReactiveUI.Fody Limitation

### DIFF
--- a/input/docs/handbook/view-models/boilerplate-code.md
+++ b/input/docs/handbook/view-models/boilerplate-code.md
@@ -19,6 +19,8 @@ With [ReactiveUI.Fody](https://www.nuget.org/packages/ReactiveUI.Fody/), you don
 public string Name { get; set; }
 ```
 
+> **Note** `ReactiveUI.Fody` currently doesn't support inline auto property initializers. Don't attempt to write code like `public string Name { get; set; } = "Name";`, this won't work as you expect and will likely throw a very weird exception. To workaround this limitation, move your property initialization code to the constructor of your view model class. We know about this limitation and [have a tracking issue for this](https://github.com/reactiveui/ReactiveUI/issues/2416).
+
 # ObservableAsPropertyHelper properties
 
 Similarly, to declare output properties, the code looks like this:


### PR DESCRIPTION
<!-- Please read first the [Contribute](https://github.com/reactiveui/reactiveui#contribute) section of the README file -->

**What are the main goals of this change?**
- [ ] Better readability (style, grammar, spelling...)
- [ ] Content correction (accuracy, wrong information...)
- [x] New content

This PR documents a known ReactiveUI.Fody limitation related to C# auto property initializers. Based on a conversation in [Slack](http://reactiveui.net/slack).