### PR TITLE
add a definition for OAPH before it is first used.

### DIFF
--- a/input/docs/getting-started/compelling-example.md
+++ b/input/docs/getting-started/compelling-example.md
@@ -84,7 +84,7 @@ We also need a NuGet client library in this tutorial, and we are going to instal
             // everything up until this point has been running on a separate thread due 
             // to the Throttle().
             //
-            // We then use a ObservableAsPropertyHelper and the ToProperty() method to allow
+            // We then use an ObservableAsPropertyHelper, OAPH, and the ToProperty() method to allow
             // us to have the latest results that we can expose through the property to the View.
             _searchResults = this
                 .WhenAnyValue(x => x.SearchTerm)


### PR DESCRIPTION
The text describes OAPH on line 99, but never defines what it means. It is left to the user to figure that out. In most cases that is fine, however, I feel it is more clear if explicitly mentioned on line 87 before it is used. Especially helpful to people new to all this jargon.

<!-- Please read first the [Contribute](https://github.com/reactiveui/reactiveui#contribute) section of the README file -->

**What are the main goals of this change?**
- [x] Better readability (style, grammar, spelling...)
- [ ] Content correction (accuracy, wrong information...)
- [ ] New content


**Is this change related to any reported issue? (Optional)**
<!-- Link to issues here. -->


**Notes (Optional)**
