### PR TITLE
🦜 ReactiveUI.Fody property initializers limitation only applies to generic types

### DIFF
--- a/input/docs/handbook/view-models/boilerplate-code.md
+++ b/input/docs/handbook/view-models/boilerplate-code.md
@@ -19,7 +19,7 @@ With [ReactiveUI.Fody](https://www.nuget.org/packages/ReactiveUI.Fody/), you don
 public string Name { get; set; }
 ```
 
-> **Note** `ReactiveUI.Fody` currently doesn't support inline auto property initializers. Don't attempt to write code like `public string Name { get; set; } = "Name";`, this won't work as you expect and will likely throw a very weird exception. To workaround this limitation, move your property initialization code to the constructor of your view model class. We know about this limitation and [have a tracking issue for this](https://github.com/reactiveui/ReactiveUI/issues/2416).
+> **Note** `ReactiveUI.Fody` currently doesn't support inline auto property initializers in generic types. It works fine with non-generic types. But if you are working on a generic type, don't attempt to write code like `public string Name { get; set; } = "Name";`, this won't work as you might expect and will likely throw a very weird exception. To workaround this limitation, move your property initialization code to the constructor of your view model class. We know about this limitation and [have a tracking issue for this](https://github.com/reactiveui/ReactiveUI/issues/2416).
 
 # ObservableAsPropertyHelper properties
 


### PR DESCRIPTION
<!-- Please read first the [Contribute](https://github.com/reactiveui/reactiveui#contribute) section of the README file -->

**What are the main goals of this change?**
- [ ] Better readability (style, grammar, spelling...)
- [x] Content correction (accuracy, wrong information...)
- [ ] New content


**Is this change related to any reported issue? (Optional)**
reactiveui/ReactiveUI#2416


**Notes (Optional)**
Previous description makes it seem like non-generic types are impacted as well, which isn't true. This change clarifies the situation.