### PR TITLE
fix: typo in OAPH documentation

### DIFF
--- a/input/docs/handbook/observable-as-property-helper/index.md
+++ b/input/docs/handbook/observable-as-property-helper/index.md
@@ -79,7 +79,7 @@ firstName = this
 ```
 
 ## Defer Subscription
-If you are creating a large number of OAPH, consider deferring your subscription. `ToProperty` also allows you to deferSubscription to the underlying `IObservable<T>`. Deferring the subscription not have the OAPH Subscribe to the base `IObserable<T>` until the Value property has been accessed. This is especially useful if you have more complex `IObservable<T>` because this approach is very close to the approach that `Lazy<T>` takes. 
+If you are creating a large number of OAPH, consider deferring your subscription. `ToProperty` also allows you to deferSubscription to the underlying `IObservable<T>`. Deferring the subscription not have the OAPH Subscribe to the base `IObservable<T>` until the Value property has been accessed. This is especially useful if you have more complex `IObservable<T>` because this approach is very close to the approach that `Lazy<T>` takes. 
 
 ```cs
 // nameStatusObservable is IObservable<string>


### PR DESCRIPTION
<!-- Please read first the [Contribute](https://github.com/reactiveui/reactiveui#contribute) section of the README file -->

**What are the main goals of this change?**
- [x] Better readability (style, grammar, spelling...)
- [ ] Content correction (accuracy, wrong information...)
- [ ] New content


**Is this change related to any reported issue? (Optional)**
<!-- Link to issues here. -->


**Notes (Optional)**
