### PR TITLE
Updated AvaloniaUI routing guide link

### DIFF
--- a/input/docs/handbook/routing/index.md
+++ b/input/docs/handbook/routing/index.md
@@ -34,7 +34,7 @@ The following elements participate in routing:
 > Other resources: 
 > - [ViewModel Routing with ReactiveUI and Xamarin.Forms](https://jamilgeor.com/viewmodel-routing-with-reactiveui-and-xamarin-forms/), by Jamil Geor
 > - [Sextant](https://github.com/reactiveui/sextant) library for advanced XF routing
-> - [AvaloniaUI routing guide](https://avaloniaui.net/docs/reactiveui/routing)
+> - [AvaloniaUI routing guide](https://docs.avaloniaui.net/guides/deep-dives/reactiveui/routing)
 > - [Universal Windows Platform routing samples](https://github.com/reactiveui/ReactiveUI.Samples/tree/main/uwp).
 
 Using Visual Studio, create a new WPF project and name it 'ReactiveRouting'. Install the `ReactiveUI.WPF` NuGet package into the project. Now create a view model named `FirstViewModel` that implements the `IRoutableViewModel` interface. The `IRoutableViewModel.UrlPathSegment` property is a string token representing the current view model, such as 'login' or 'user'. You are free to choose any string. In this example, we use 'first'. The `HostScreen` property typically contains the instance of the host screen used by an application.


### PR DESCRIPTION
The link for the routing guide for AvaloniaUI was dead so I updated it to the new one.

<!-- Please read first the [Contribute](https://github.com/reactiveui/reactiveui#contribute) section of the README file -->

**What are the main goals of this change?**
- [ ] Better readability (style, grammar, spelling...)
- [ ] Content correction (accuracy, wrong information...)
- [ ] New content


**Is this change related to any reported issue? (Optional)**
<!-- Link to issues here. -->


**Notes (Optional)**
