### PR TITLE
fix: Correct Code Sample on the Routing Page

### DIFF
--- a/input/docs/handbook/routing/index.md
+++ b/input/docs/handbook/routing/index.md
@@ -135,8 +135,16 @@ public class MainViewModel : ReactiveObject, IScreen
         //
         GoNext = ReactiveCommand.CreateFromObservable(() => Router.Navigate.Execute(new FirstViewModel()));
 
-        // You can also ask the router to go back.
-        GoBack = Router.NavigateBack;
+        // You can also ask the router to go back. One option is to 
+        // execute the default Router.NavigateBack command. Another
+        // option is to define your own command with custom
+        // canExecute condition as such:
+        var canGoBack = this
+            .WhenAnyValue(x => x.Router.NavigationStack.Count)
+            .Select(count => count > 0);
+        GoBack = ReactiveCommand.CreateFromObservable(
+            () => Router.NavigateBack.Execute(Unit.Default),
+            canGoBack);
     }
 }
 ```


### PR DESCRIPTION
<!-- Please read first the [Contribute](https://github.com/reactiveui/reactiveui#contribute) section of the README file -->

**What are the main goals of this change?**
- [ ] Better readability (style, grammar, spelling...)
- [x] Content correction (accuracy, wrong information...)
- [ ] New content

**Is this change related to any reported issue? (Optional)**
<!-- Link to issues here. -->

Use the correction from https://github.com/reactiveui/ReactiveUI/issues/2076#issuecomment-774244290

Now the code on the ReactiveUI [Routing](https://www.reactiveui.net/docs/handbook/routing/) documentation page behaves as the GIF image shows, the `RoutedViewHost` now goes back to the default content. Also, now you don't have to click the "Next page" button twice in order to enable the "Go back" button.
