### PR TITLE
fix: Update UWP installation instructions

### DIFF
--- a/input/docs/getting-started/installation/universal-windows-platform.md
+++ b/input/docs/getting-started/installation/universal-windows-platform.md
@@ -14,5 +14,6 @@ Assuming the following project structure:
 ```
 
 * Install `ReactiveUI` into your netstandard library, platform library, application and tests.
+* Install `ReactiveUI.UWP` into your application.
 * Install `ReactiveUI.Events` into your netstandard library and application.
 * Install `ReactiveUI.Testing` into your tests.


### PR DESCRIPTION
We now have a `ReactiveUI.Uwp` package and the installation instructions are a bit misleading as they're not mentioning the new package:  https://www.reactiveui.net/docs/getting-started/installation/universal-windows-platform

If `ReactiveUI.Uwp` package isn't installed, the app crashes:
`System.ArgumentException: "Don't know how to detect when LoginApp.Uwp.Views.SignUpView is activated/deactivated, you may need to implement IActivationForViewFetcher"`