### PR TITLE
Clarify OAPH use case

### DIFF
--- a/input/docs/handbook/observable-as-property-helper/index.md
+++ b/input/docs/handbook/observable-as-property-helper/index.md
@@ -1,4 +1,6 @@
-The ObservableAsPropertyHelper (OAPH) is a class that simplifies the interop between an IObservable and a property on your View Model. It allows you to have a property which reflects the latest value that has been sent through the IObservable<T> stream. 
+The ObservableAsPropertyHelper (OAPH) is a class that simplifies the interop between an IObservable and a property on your ViewModel. It allows you to have a property which reflects the latest value that has been sent through the IObservable<T> stream. 
+
+It is important to note, that OAPH will not set the property value immediatly, but will rather schedule it on provided, or default scheduler. For bussiness critical parts of code, `[Reactive]` property with `.BindTo()` should be used.
   
 It will invoke the `INotifyPropertyChanged` and `INotifyPropertyChanging` based events for the View Model when the observable emits a new value. `ObservableAsPropertyHelper<T>` is very similar to a Lazy<T> in so far as it provides a Value member which provides the latest value of the Observable<T>. They are often read-only and reflect the IObservable<T> stream. It is common to combine ObservableAsPropertyHelper<T> with the `WhenAny` extensions. 
 


### PR DESCRIPTION
There was slack thread, where OAPH was missused and thus creating unexpected behavior of the code

![image](https://user-images.githubusercontent.com/34779382/179179717-cd46bd45-06c6-49ff-8e87-c0e54bdcd911.png)
