### PR TITLE
Project Structure New Content

### DIFF
--- a/input/contribute/compiling-reactive-ui/project-structure.md
+++ b/input/contribute/compiling-reactive-ui/project-structure.md
@@ -1,13 +1,46 @@
-nn
-# EventBuilder
-# ReactiveUI.AndroidSupport
-# ReactiveUI.Blend
-# ReactiveUI.Events.WPF
-# ReactiveUI.Events.XamForms
-# ReactiveUI.Events
-# ReactiveUI.Testing
-# ReactiveUI.Tests
-# ReactiveUI.Winforms
-# ReactiveUI.Wpf
-# ReactiveUI.XamForms
 # ReactiveUI
+[ReactiveUI](https://www.reactiveui.net/api/reactiveui/) is a MVVM framework that integrates with the Reactive Extensions for .NET to create elegant, testable User Interfaces that run on any mobile or desktop platform. This is the base package with the base platform implementations.
+
+# ReactiveUI.AndroidSupport
+ The [ReactiveUI.AndroidSupport](https://www.reactiveui.net/docs/guidelines/platform/xamarin-android) package provides ReactiveUI extensions for the [Android Support Library](https://www.tutorialspoint.com/android/android_support_library.htm#:~:text=The%20Android%20Support%20Library%20package%20is%20a%20set,is%20backward-compatible%20to%20a%20specific%20Android%20API%20level.). The Android Support Library is no longer maintained as of 2018 and has been replaced with AndroidX.
+
+# ReactiveUI.AndroidX
+The [ReactiveUI.AndroidX](https://www.reactiveui.net/docs/guidelines/platform/xamarin-android) package provides ReactiveUI extensions for the [AndroidX Library](https://developer.android.com/jetpack/androidx). 
+
+# ReactiveUI.Blazor
+The [ReactiveUI.Blazor](https://www.reactiveui.net/docs/guidelines/platform/blazor) package contains the ReactiveUI platform specific extensions for [Blazor](https://dotnet.microsoft.com/en-us/apps/aspnet/web-apps/blazor). 
+
+# ReactiveUI.Blend
+The [ReactiveUI.Blend](https://www.reactiveui.net/api/reactiveui.blend/) package provides reactive extensions based xaml components based on the Blend SDK library, allowing you to fire a observable from XAML.
+
+# ReactiveUI.Drawing
+The [ReactiveUI.Drawing](https://www.reactiveui.net/api/reactiveui.drawing/) package is an extension to the ReactiveUI platform that provides [Splat](https://github.com/reactiveui/splat) bitmap operation support .
+
+# ReactiveUI.Fody
+The [ReactiveUI.Fody](https://www.reactiveui.net/api/reactiveui.fody/) package is a [Fody](https://github.com/Fody/Fody) extension that will generate RaisePropertyChange notifications for properties and ObservableAsPropertyHelper properties.
+
+# ReactiveUI.Fody.Analyzer
+The [ReactiveUI.Fody.Analyzer](https://www.reactiveui.net/api/reactiveui.fody.analyzer/) package is a [Roslyn](https://learn.microsoft.com/en-us/dotnet/csharp/roslyn-sdk/) extension that checks correct usage of the [Fody](https://github.com/Fody/Fody) extension.
+
+# ReactiveUI.Fody.Helpers
+The [ReactiveUI.Fody.Helpers](https://www.reactiveui.net/api/reactiveui.fody.helpers/) package [Fody](https://github.com/Fody/Fody) extension to generate RaisePropertyChange notifications for properties and ObservableAsPropertyHelper properties.
+# ReactiveUI.Maui
+The [ReactiveUI.Maui](https://www.reactiveui.net/api/reactiveui.maui/) package contains the ReactiveUI platform specific extensions for [Microsoft Maui](https://dotnet.microsoft.com/en-us/apps/maui).
+
+# ReactiveUI.Testing
+The [ReactiveUI.Testing](https://www.reactiveui.net/api/reactiveui.testing/) package provides extensions for testing ReactiveUI based applications.
+
+# ReactiveUI.Uwp
+The [ReactiveUI.Uwp](https://www.reactiveui.net/api/reactiveui.uwp/) package provides ReactiveUI extensions for the [UWP Library](https://visualstudio.microsoft.com/vs/features/universal-windows-platform/).
+
+# ReactiveUI.Winforms
+The [ReactiveUI.Winforms](https://www.reactiveui.net/api/reactiveui.winforms/) package contains the ReactiveUI platform specific extensions for [Windows Forms](https://visualstudio.microsoft.com/vs/features/universal-windows-platform/).
+
+# ReactiveUI.WinUI
+The [ReactiveUI.WinUI](https://www.reactiveui.net/api/reactiveui.winui/) package contains the ReactiveUI platform specific extensions for [WinUI Desktop](https://learn.microsoft.com/en-us/windows/apps/winui/).
+
+# ReactiveUI.Wpf
+The [ReactiveUI.Wpf](https://www.reactiveui.net/api/reactiveui.wpf/) package contains the ReactiveUI platform specific extensions for [Windows Presentation Foundation (WPF)](https://learn.microsoft.com/en-us/dotnet/desktop/wpf/overview/?view=netdesktop-6.0).
+
+# ReactiveUI.XamForms
+The [ReactiveUI.XamForms](https://www.reactiveui.net/api/reactiveui.xamforms/) package contains the ReactiveUI platform specific extensions for [Xamarin Forms](https://learn.microsoft.com/en-us/xamarin/xamarin-forms/).


### PR DESCRIPTION
Wrote documentation for all the packages in ReactiveUI and hyperlinked relevant resources on the Project Structure page at https://www.reactiveui.net/contribute/compiling-reactive-ui/project-structure

**What are the main goals of this change?**
- [ ] Better readability (style, grammar, spelling...)
- [x] Content correction (accuracy, wrong information...)
- [x] New content

**Notes (Optional)**
It seemed like the current Project Structure page was referring to old packages, so I thought it might be nice to update it with new packages and link to the relevant resources. 