### PR TITLE
Typo at a(n) invalid value

### DIFF
--- a/input/docs/handbook/observable-as-property-helper/index.md
+++ b/input/docs/handbook/observable-as-property-helper/index.md
@@ -99,7 +99,7 @@ private readonly ObservableAsPropertyHelper<string> name;
 public string Name => name.Value; 
 ``` 
 
-One caveat of deferring the subscription is if you aren't careful you'll have a invalid value until a new value is added to the `IObservable<T>`. If using Hot Observables consider using a `ReplaySubject<T>` and limiting the `ReplaySubject<T>` to 1 previous value in the constructor. 
+One caveat of deferring the subscription is if you aren't careful you'll have an invalid value until a new value is added to the `IObservable<T>`. If using Hot Observables consider using a `ReplaySubject<T>` and limiting the `ReplaySubject<T>` to 1 previous value in the constructor. 
 
 ```cs
 public class StatusViewModel : ReactiveObject


### PR DESCRIPTION
Again just a typo

**What are the main goals of this change?**
- [x] Better readability (spelling)

