### PR TITLE
Add Akavache Docs section

### DIFF
--- a/reactiveui/api/index.md
+++ b/reactiveui/api/index.md
@@ -1,8 +1,12 @@
-# ReactiveUI and related projects Api Documentation
+# ReactiveUI API Documentation
 
-- Akavache
-- Fusillade
-- Punchclock
-- ReactiveUI
-- Splat
-- DynamicData
+Browse the latest API documentation generated from the current ReactiveUI source code. This section provides reference material for all major ReactiveUI packages and related projects.
+
+- [ReactiveUI API](api/ReactiveUI.html)
+- [DynamicData API](api/DynamicData.html)
+- [Splat API](api/Splat.html)
+- [Akavache API](api/Akavache.html)
+- [Fusillade API](api/Fusillade.html)
+- [Punchclock API](Punchclock.html)
+
+> The API documentation is generated from the latest source and reflects .NET 8 compatibility and current best practices.

--- a/reactiveui/docs/handbook/akavache/caches.md
+++ b/reactiveui/docs/handbook/akavache/caches.md
@@ -1,0 +1,22 @@
+# Caches
+
+Akavache exposes logical caches through a single instance:
+- LocalMachine: persistent general-purpose cache
+- Secure: encrypted persistent cache
+- InMemory: fast process-local cache
+
+```csharp
+var ak = Locator.Current.GetService<IAkavacheInstance>(contract: "MyApp");
+await ak.LocalMachine.InsertObject("user:42", user);
+var u = await ak.LocalMachine.GetObject<User>("user:42");
+
+await ak.Secure.InsertObject("token", token);
+var t = await ak.Secure.GetObject<Token>("token");
+```
+
+Expiration and bulk ops:
+```csharp
+await ak.LocalMachine.InsertObject("weather", data, TimeSpan.FromMinutes(10));
+await ak.LocalMachine.InsertObjects(items.Select(i => (i.Key, i.Value)));
+var many = await ak.LocalMachine.GetObjects<string>(keys);
+```

--- a/reactiveui/docs/handbook/akavache/images.md
+++ b/reactiveui/docs/handbook/akavache/images.md
@@ -1,0 +1,10 @@
+# Images
+
+Akavache.Drawing helpers:
+```csharp
+var bmp = await ak.LocalMachine.LoadImageFromUrl("https://example.com/p.jpg");
+await ak.LocalMachine.SaveImage("user:photo", bmp);
+var result = await ak.LocalMachine.GetImage("user:photo");
+```
+
+Each cache has its own HttpService instance used by these helpers (initialized automatically).

--- a/reactiveui/docs/handbook/akavache/index.md
+++ b/reactiveui/docs/handbook/akavache/index.md
@@ -1,0 +1,5 @@
+# Akavache (v11)
+
+Akavache is an asynchronous, persistent key-value store for .NET applications, ideal for local caching, offline enablement, and secure storage.
+
+This section documents Akavache v11.0.1 with builder-based configuration, modular packages, multiple serializers, typed settings, image helpers, and more.

--- a/reactiveui/docs/handbook/akavache/installation.md
+++ b/reactiveui/docs/handbook/akavache/installation.md
@@ -1,0 +1,26 @@
+# Installation
+
+Akavache v11 uses modular packages and a builder-based initialization for flexible setup and DI.
+
+Packages:
+- Akavache (core abstractions/in-memory)
+- Akavache.Sqlite3 (persistence)
+- Akavache.SystemTextJson (serializer, recommended) or Akavache.NewtonsoftJson
+- Akavache.Settings (typed settings)
+- Akavache.Drawing (image helpers)
+
+Quick start (Splat builder):
+```csharp
+AppBuilder.CreateSplatBuilder()
+    .WithAkavache<SystemJsonSerializer>(
+        "MyApp",
+        b => b.WithSqliteDefaults()
+              .WithForceDateTimeKind(DateTimeKind.Utc),
+        (splat, instance) =>
+        {
+            splat.RegisterLazySingleton<IBlobCache>(() => instance.LocalMachine, contract: nameof(instance.LocalMachine));
+            splat.RegisterLazySingleton<IAkavacheInstance>(() => instance, contract: instance.ApplicationName);
+        });
+```
+
+MAUI: call the above in MauiProgram.CreateMauiApp.

--- a/reactiveui/docs/handbook/akavache/migration.md
+++ b/reactiveui/docs/handbook/akavache/migration.md
@@ -1,0 +1,18 @@
+# Migration (v10 ? v11)
+
+Key changes:
+- Static BlobCache ? builder + IAkavacheInstance
+- Modular packages
+- Pluggable serializers
+
+Example:
+```csharp
+// v10
+BlobCache.LocalMachine.InsertObject("user", user);
+
+// v11
+var ak = Locator.Current.GetService<IAkavacheInstance>(contract: "MyApp");
+ak.LocalMachine.InsertObject("user", user);
+```
+
+Test serializer migration paths and back up caches.

--- a/reactiveui/docs/handbook/akavache/performance.md
+++ b/reactiveui/docs/handbook/akavache/performance.md
@@ -1,0 +1,6 @@
+# Performance
+
+- Prefer System.Text.Json
+- Use bulk ops for throughput
+- Set expirations to control growth
+- Use InMemory for hot-path transient data

--- a/reactiveui/docs/handbook/akavache/serialization.md
+++ b/reactiveui/docs/handbook/akavache/serialization.md
@@ -1,0 +1,21 @@
+# Serialization
+
+Choose a serializer package and configure via builder.
+
+System.Text.Json (recommended):
+```csharp
+var serializer = new SystemJsonSerializer
+{
+    Options = new JsonSerializerOptions
+    {
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+        DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull
+    }
+};
+
+AppBuilder.CreateSplatBuilder()
+    .WithAkavache<SystemJsonSerializer>(() => serializer,
+        b => b.WithSqliteDefaults());
+```
+
+Cross-serializer compatibility allows reading legacy JSON/BSON. Test migrations and back up caches before switching serializers.

--- a/reactiveui/docs/handbook/akavache/settings.md
+++ b/reactiveui/docs/handbook/akavache/settings.md
@@ -1,0 +1,19 @@
+# Settings
+
+Typed settings via Akavache.Settings:
+```csharp
+public class AppSettings : SettingsBase
+{
+    public AppSettings() : base(nameof(AppSettings)) {}
+    public bool EnableNotifications { get => GetOrCreate(true); set => SetOrCreate(value); }
+    public string Theme { get => GetOrCreate("Light"); set => SetOrCreate(value); }
+}
+
+AppBuilder.CreateSplatBuilder()
+    .WithAkavache<SystemJsonSerializer>("MyApp",
+        b => b.WithSqliteDefaults()
+              .WithSecureSettingsStore<AppSettings>(out var settings));
+
+var enabled = settings.EnableNotifications;
+settings.Theme = "Dark";
+```

--- a/reactiveui/docs/handbook/akavache/toc.yml
+++ b/reactiveui/docs/handbook/akavache/toc.yml
@@ -1,0 +1,20 @@
+- name: Akavache (v11)
+  href: index.md
+- name: Installation
+  href: installation.md
+- name: Caches
+  href: caches.md
+- name: Usage
+  href: usage.md
+- name: Serialization
+  href: serialization.md
+- name: Settings
+  href: settings.md
+- name: Images
+  href: images.md
+- name: Migration (v10 ? v11)
+  href: migration.md
+- name: Performance
+  href: performance.md
+- name: Troubleshooting
+  href: troubleshooting.md

--- a/reactiveui/docs/handbook/akavache/troubleshooting.md
+++ b/reactiveui/docs/handbook/akavache/troubleshooting.md
@@ -1,0 +1,7 @@
+# Troubleshooting
+
+- Ensure Sqlite native support is present when using Akavache.Sqlite3.
+- Back up caches before changing serializers.
+- Provide a secure key management strategy for the Secure cache.
+- For images, verify Akavache.Drawing is referenced.
+- Enable logging with Splat to debug cache operations and errors.

--- a/reactiveui/docs/handbook/akavache/usage.md
+++ b/reactiveui/docs/handbook/akavache/usage.md
@@ -1,0 +1,21 @@
+# Usage
+
+Common operations:
+```csharp
+// strings/bytes
+await ak.LocalMachine.Insert("msg", Encoding.UTF8.GetBytes("hello"));
+var bytes = await ak.LocalMachine.Get("msg");
+
+// POCO
+await ak.LocalMachine.InsertObject("user", user);
+var user2 = await ak.LocalMachine.GetObject<User>("user");
+
+// GetOrFetch with expiration (throttles dup requests)
+var posts = await ak.LocalMachine.GetOrFetchObject("posts",
+    () => api.GetPostsAsync(), TimeSpan.FromMinutes(5));
+
+// exists/invalidate
+bool exists = await ak.LocalMachine.Exists("user");
+await ak.LocalMachine.Invalidate("user");
+await ak.LocalMachine.InvalidateAll();
+```

--- a/reactiveui/docs/handbook/index.md
+++ b/reactiveui/docs/handbook/index.md
@@ -1,4 +1,32 @@
 ---
-NoTitle: true
 Order: 15
 ---
+# ReactiveUI Handbook
+
+Welcome to the ReactiveUI Handbook. This section provides comprehensive documentation for using ReactiveUI with .NET 8 and the latest best practices. Explore the topics below to learn about core concepts, advanced features, platform-specific guidance, and related projects.
+
+## Core Topics
+- [Commands](commands/index.md)
+- [Data Binding](data-binding/index.md)
+- [View Models](view-models/index.md)
+- [Interactions](interactions/index.md)
+- [Logging](logging/index.md)
+- [Dependency Inversion](dependency-inversion/index.md)
+- [View Location](view-location/index.md)
+- [Scheduling](scheduling.md)
+- [Testing](testing.md)
+
+## Related Projects
+- [Akavache (v11)](akavache/index.md)
+
+## Platform Guides
+- [Xamarin.Android](data-binding/xamarin-android/index.md)
+- [Windows Presentation Foundation (WPF)](../getting-started/installation/windows-presentation-foundation.md)
+- [WinUI](../getting-started/installation/winui.md)
+- [MAUI](../getting-started/installation/maui.md)
+- [Blazor](../getting-started/installation/blazor.md)
+
+## Upgrading & Migration
+- [Upgrading](../upgrading/index.md)
+
+For more details, see the [API Documentation](../../api/index.md).

--- a/reactiveui/docs/handbook/toc.yml
+++ b/reactiveui/docs/handbook/toc.yml
@@ -44,3 +44,5 @@
   href: when-activated.md
 - name: When Any
   href: when-any.md
+- name: Akavache (v11)
+  href: akavache/toc.yml


### PR DESCRIPTION
<!-- Please read first the [Contribute](https://github.com/reactiveui/reactiveui#contribute) section of the README file -->

**What are the main goals of this change?**
- [ ] Better readability (style, grammar, spelling...)
- [ ] Content correction (accuracy, wrong information...)
- [x] New content

This pull request adds comprehensive Akavache v11 documentation to the ReactiveUI handbook and updates related navigation and API docs to improve discoverability and usability. It introduces new guides covering installation, usage, serialization, settings, images, migration, performance, and troubleshooting for Akavache, and integrates these into the handbook’s structure and table of contents. The API documentation index is also restructured for clarity.

**Akavache Documentation Additions:**

* Added new handbook pages for Akavache v11, including guides for installation, usage, caches, serialization, settings, images, migration from v10, performance, and troubleshooting. 

* Added a dedicated Akavache table of contents (`akavache/toc.yml`) for easy navigation of the new documentation.

**Handbook and Navigation Updates:**

* Updated the main handbook index to reference Akavache and reorganized platform and core topics for improved clarity.

* Integrated Akavache documentation into the handbook table of contents for seamless access.

**API Documentation Improvements:**

* Rewrote the API documentation index to clearly list and link all major ReactiveUI-related projects, including Akavache, and highlight .NET 8 compatibility.
