### PR TITLE
docs: refresh API and platform guidance

### DIFF
--- a/reactiveui/api/index.md
+++ b/reactiveui/api/index.md
@@ -1,6 +1,6 @@
 # ReactiveUI API Documentation
 
-Browse the latest API documentation generated from the current ReactiveUI source code. This section provides reference material for all major ReactiveUI packages and related projects.
+Browse the latest API documentation for all major ReactiveUI packages and related projects. This section is generated from the published NuGet packages and reflects the latest stable releases.
 
 - [Akavache API](akavache.html)
 - [DynamicData API](dynamicdata.html)
@@ -38,4 +38,4 @@ Browse the latest API documentation generated from the current ReactiveUI source
 - [Fusillade API](fusillade.html)
 - [Punchclock API](punchclock.html)
 
-> The API documentation is generated from the latest source and reflects .NET 8 compatibility and current best practices.
+> The API documentation is generated from the latest stable NuGet package releases and reflects current best practices.

--- a/reactiveui/docs/getting-started/installation/maui.md
+++ b/reactiveui/docs/getting-started/installation/maui.md
@@ -30,23 +30,19 @@ public static class MauiProgram
         var builder = MauiApp.CreateBuilder();
         builder
             .UseMauiApp<App>()
-            .ConfigureReactiveUI();
-
-        // Initialize ReactiveUI with RxAppBuilder
-        var app = RxAppBuilder.CreateReactiveUIBuilder()
-            .WithMaui()
-            .WithViewsFromAssembly(typeof(App).Assembly)
-            .WithRegistration(locator =>
-            {
-                // Register your services
-                locator.RegisterLazySingleton<INavigationService>(() => new NavigationService());
-                locator.RegisterLazySingleton<IDataService>(() => new DataService());
-            })
-            .BuildApp();
-
-        // Optional: Register additional MAUI-specific services
-        builder.Services.AddSingleton(app.MainThreadScheduler);
-        builder.Services.AddSingleton(app.TaskpoolScheduler);
+            // Initialize ReactiveUI with RxAppBuilder
+            .UseReactiveUI(rxAppBuilder =>
+            {    
+                rxAppBuilder
+                    .WithMaui()
+                    .WithViewsFromAssembly(typeof(App).Assembly)
+                    .WithRegistration(locator =>
+                    {
+                        // Register your services here
+                        locator.RegisterLazySingleton<INavigationService>(() => new NavigationService());
+                        locator.RegisterLazySingleton<IDataService>(() => new DataService());
+                    });
+            });
 
         return builder.Build();
     }

--- a/reactiveui/docs/getting-started/installation/windows-forms.md
+++ b/reactiveui/docs/getting-started/installation/windows-forms.md
@@ -28,12 +28,12 @@ Install the following packages for ReactiveUI with Windows Forms:
 
 ### Framework Requirements
 
-Ensure you are targeting at least .NET 8.0 with Windows 10.0.17763.0:
+Ensure you are targeting at least .NET 8.0 with Windows 10.0.19041.0:
 
 ```xml
-<TargetFramework>net8.0-windows10.0.17763.0</TargetFramework>
+<TargetFramework>net8.0-windows10.0.19041.0</TargetFramework>
 <!-- Or for .NET 9/10 -->
-<TargetFramework>net10.0-windows10.0.17763.0</TargetFramework>
+<TargetFramework>net10.0-windows10.0.19041.0</TargetFramework>
 ```
 
 ## Getting Started with RxAppBuilder (Recommended)

--- a/reactiveui/docs/guidelines/platform/windows-forms.md
+++ b/reactiveui/docs/guidelines/platform/windows-forms.md
@@ -3,9 +3,9 @@
 Ensure that you install `ReactiveUI.WinForms` into your application.
 
 
-Please ensure that you are targeting at least windows10.0.17763.0
+Please ensure that you are targeting at least windows10.0.19041.0
 
-i.e `<TargetFramework>net8.0-windows10.0.17763.0</TargetFramework>` in your csproj file.
+i.e `<TargetFramework>net8.0-windows10.0.19041.0</TargetFramework>` in your csproj file.
 
 Your viewmodels should inherit from `ReactiveObject`
 

--- a/reactiveui/toc.yml
+++ b/reactiveui/toc.yml
@@ -4,6 +4,14 @@
 - name: Api
   href: api/
   homepage: api/index.md
+- name: Api - Android
+  href: api-android/
+- name: Api - iOS
+  href: api-ios/
+- name: Api - macOS
+  href: api-maccatalyst/
+- name: Api - Windows
+  href: api-windows/
 - name: Contribute
   href: contribute/
   homepage: contribute/index.md


### PR DESCRIPTION
## Summary
Refresh the website content around generated API docs and platform setup guidance.

## Changes
- Update the API landing page copy to explain that the published API docs are generated from the latest stable NuGet package releases.
- Update the MAUI installation guide to show the current `UseReactiveUI(...)` setup pattern with `RxAppBuilder`.
- Update the Windows Forms installation and platform guidance to use Windows `10.0.19041.0` in the target framework examples.
- Add platform-specific API entries to the site navigation for Android, iOS, macOS, and Windows.